### PR TITLE
feat: user 관련 - 회원조회, 수정, 프로필 이미지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.8'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/todo/config/JacksonConfig.java
+++ b/src/main/java/com/todo/config/JacksonConfig.java
@@ -1,0 +1,36 @@
+package com.todo.config;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  @Bean
+  public ObjectMapper objectMapper() {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    JavaTimeModule javaTimeModule = new JavaTimeModule();
+    javaTimeModule.addSerializer(LocalDateTime.class,
+        new LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+    objectMapper.registerModule(javaTimeModule);
+
+    objectMapper.disable(WRITE_DATES_AS_TIMESTAMPS);
+
+    objectMapper.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
+    objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+
+    return objectMapper;
+  }
+}

--- a/src/main/java/com/todo/config/SecurityConfig.java
+++ b/src/main/java/com/todo/config/SecurityConfig.java
@@ -31,7 +31,10 @@ public class SecurityConfig {
                 "/api/auth/check-email",
                 "/api/auth/sign-in",
                 "/api/auth/refresh",
-                "/api/auth/sign-out").permitAll()
+                "/api/auth/sign-out",
+                "/api/images/profile/upload",
+                "/uploads/**",
+                "/api/users/info/**").permitAll()
             .anyRequest().authenticated())
         .authenticationProvider(authenticationProvider)
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/todo/config/WebConfig.java
+++ b/src/main/java/com/todo/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.todo.config;
+
+import lombok.NonNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addResourceHandlers(@NonNull ResourceHandlerRegistry registry) {
+    registry.addResourceHandler("/uploads/**")
+        .addResourceLocations("file:uploads/");
+  }
+}

--- a/src/main/java/com/todo/image/controller/ImageController.java
+++ b/src/main/java/com/todo/image/controller/ImageController.java
@@ -1,0 +1,25 @@
+package com.todo.image.controller;
+
+import com.todo.image.service.ImageService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+  private final ImageService imageService;
+
+  @PostMapping("/profile/upload")
+  public ResponseEntity<Map<String, String>> uploadImage(@RequestParam("image") MultipartFile image) {
+
+    return ResponseEntity.ok(Map.of("imageUrl", imageService.uploadImage(image)));
+  }
+}

--- a/src/main/java/com/todo/image/service/ImageService.java
+++ b/src/main/java/com/todo/image/service/ImageService.java
@@ -1,0 +1,92 @@
+package com.todo.image.service;
+
+import static com.todo.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.todo.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
+import static java.util.Locale.ROOT;
+
+import com.todo.exception.CustomException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageService {
+
+  private static final List<String> ALLOWED_FILE_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif");
+
+  private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  private static final int MAX = 800;
+
+  public String uploadImage(MultipartFile image) {
+
+    String extension = getExtension(image);
+
+    String folder = "uploads/profile/";
+    File dir = new File(folder);
+    if (!dir.exists()) {
+      boolean created = dir.mkdirs();
+      if (!created) {
+        throw new CustomException(INTERNAL_SERVER_ERROR, "프로필 이미지 저장 폴더 생성에 실패하였습니다.");
+      }
+    }
+
+    String filename = UUID.randomUUID() + "." + extension;
+    File dest = new File(dir, filename);
+
+    try {
+      Thumbnails.of(image.getInputStream())
+          .size(MAX, MAX)
+          .outputFormat(extension)
+          .toFile(dest);
+    } catch (IOException e) {
+      throw new CustomException(INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다.");
+    }
+
+    return "/uploads/profile/" + filename;
+  }
+
+  private static String getExtension(MultipartFile image) {
+
+    if (image.isEmpty()) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL, "업로드할 이미지 파일이 없습니다.");
+    }
+
+    if (image.getSize() > MAX_FILE_SIZE) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL, "파일 용량은 최대 5MB 를 초과할 수 없습니다.");
+    }
+
+    String originalFilename = image.getOriginalFilename();
+    if (originalFilename == null || !originalFilename.contains(".")) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL, "파일 확장자를 확인할 수 없습니다.");
+    }
+
+    String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1)
+        .toLowerCase(ROOT);
+    if (!ALLOWED_FILE_EXTENSIONS.contains(extension)) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL, "허용되지 않은 파일 형식 입니다.");
+    }
+    return extension;
+  }
+
+  public String updateProfileImage(String currentImageUrl, MultipartFile image) {
+
+    if (currentImageUrl != null && !currentImageUrl.isEmpty()) {
+
+      String filePath = currentImageUrl.replaceFirst("^/uploads/", "uploads/");
+      File existingFile = new File(filePath);
+      if (existingFile.exists() && !existingFile.delete()) {
+        log.error("Failed to delete existing file: {}", filePath);
+      }
+    }
+    return uploadImage(image);
+  }
+}

--- a/src/main/java/com/todo/user/controller/UserController.java
+++ b/src/main/java/com/todo/user/controller/UserController.java
@@ -1,0 +1,55 @@
+package com.todo.user.controller;
+
+import com.todo.user.dto.ChangePasswordDto;
+import com.todo.user.dto.UserResponseDto;
+import com.todo.user.service.UserService;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+  private final UserService userService;
+
+  @GetMapping("/me")
+  public ResponseEntity<UserResponseDto> getMyInfo(Authentication auth) {
+
+    return ResponseEntity.ok(userService.getMyInfo(auth));
+  }
+
+  @PutMapping("/me/reset-password")
+  public ResponseEntity<UserResponseDto> changePassword(Authentication auth,
+      @RequestBody @Valid ChangePasswordDto changePasswordDto) {
+
+    return ResponseEntity.ok(userService.changePassword(auth, changePasswordDto));
+  }
+
+  @GetMapping("/info/{userId}")
+  public ResponseEntity<UserResponseDto> getUser(@PathVariable Long userId) {
+
+    return ResponseEntity.ok(userService.getUser(userId));
+  }
+
+  @PostMapping("/me/profile")
+  public ResponseEntity<Map<String, String>> updateProfileImage(
+      Authentication auth,
+      @RequestParam("image") MultipartFile image) {
+
+    return ResponseEntity.ok(
+        Map.of("profileImageUrl", userService.updateProfileImage(auth, image)));
+  }
+}

--- a/src/main/java/com/todo/user/dto/ChangePasswordDto.java
+++ b/src/main/java/com/todo/user/dto/ChangePasswordDto.java
@@ -1,0 +1,16 @@
+package com.todo.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordDto(
+
+    @NotBlank(message = "비밀번호는 필수 입력 입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    String password,
+
+    @NotBlank(message = "현재 비밀번호는 필수 입력 입니다.")
+    String confirmPassword
+) {
+
+}

--- a/src/main/java/com/todo/user/dto/UserResponseDto.java
+++ b/src/main/java/com/todo/user/dto/UserResponseDto.java
@@ -1,0 +1,27 @@
+package com.todo.user.dto;
+
+import com.todo.user.entity.User;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record UserResponseDto(
+
+    String email,
+    String phone,
+    String name,
+    String profileImageUrl,
+    LocalDateTime createdAt
+) {
+
+  public static UserResponseDto fromEntity(User user) {
+
+    return UserResponseDto.builder()
+        .email(user.getEmail())
+        .phone(user.getPhone())
+        .name(user.getName())
+        .profileImageUrl(user.getProfileImageUrl())
+        .createdAt(user.getCreateAt())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/user/entity/User.java
+++ b/src/main/java/com/todo/user/entity/User.java
@@ -59,4 +59,13 @@ public class User {
         .profileImageUrl(authDto.profileImageUrl())
         .build();
   }
+
+  public void updatePassword(String newPassword) {
+
+    password = newPassword;
+  }
+
+  public void updateProfileImage(String newImageUrl) {
+    profileImageUrl = newImageUrl;
+  }
 }

--- a/src/main/java/com/todo/user/service/UserQueryService.java
+++ b/src/main/java/com/todo/user/service/UserQueryService.java
@@ -19,4 +19,8 @@ public class UserQueryService {
   public User findByEmail(String email) {
     return userRepository.findByEmail(email).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
   }
+
+  public User findById(Long id) {
+    return userRepository.findById(id).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+  }
 }

--- a/src/main/java/com/todo/user/service/UserService.java
+++ b/src/main/java/com/todo/user/service/UserService.java
@@ -1,0 +1,63 @@
+package com.todo.user.service;
+
+import static com.todo.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
+
+import com.todo.exception.CustomException;
+import com.todo.image.service.ImageService;
+import com.todo.user.dto.ChangePasswordDto;
+import com.todo.user.dto.UserResponseDto;
+import com.todo.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+  private final UserQueryService userQueryService;
+
+  private final PasswordEncoder passwordEncoder;
+
+  private final ImageService imageService;
+
+  public UserResponseDto getMyInfo(Authentication auth) {
+
+    return UserResponseDto.fromEntity(userQueryService.findByEmail(auth.getName()));
+  }
+
+  @Transactional
+  public UserResponseDto changePassword(Authentication auth, ChangePasswordDto changePasswordDto) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    if (!passwordEncoder.matches(changePasswordDto.confirmPassword(), user.getPassword())) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL, "현재 비밀번호가 올바르지 않습니다.");
+    }
+
+    user.updatePassword(passwordEncoder.encode(changePasswordDto.password()));
+
+    return UserResponseDto.fromEntity(user);
+  }
+
+  public UserResponseDto getUser(Long userId) {
+
+    return UserResponseDto.fromEntity(userQueryService.findById(userId));
+  }
+
+  @Transactional
+  public String updateProfileImage(Authentication auth, MultipartFile image) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    String newImageUrl = imageService.updateProfileImage(user.getProfileImageUrl(), image);
+
+    user.updateProfileImage(newImageUrl);
+
+    return newImageUrl;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,3 @@ jwt.refresh.expiration=604800000
 
 logging.level.org.hibernate.sql=info
 logging.level.org.hibernate.type.descriptor=trace
-
-spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
-spring.jackson.time-zone=Asia/Seoul

--- a/src/test/java/com/todo/user/service/UserServiceTest.java
+++ b/src/test/java/com/todo/user/service/UserServiceTest.java
@@ -1,0 +1,138 @@
+package com.todo.user.service;
+
+import static com.todo.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.core.userdetails.User.withUsername;
+
+import com.todo.exception.CustomException;
+import com.todo.image.service.ImageService;
+import com.todo.user.dto.ChangePasswordDto;
+import com.todo.user.dto.UserResponseDto;
+import com.todo.user.entity.User;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private PasswordEncoder passwordEncoder;
+
+  @Mock
+  private ImageService imageService;
+
+  @InjectMocks
+  private UserService userService;
+
+  private User testUser;
+  private Authentication auth;
+
+  @BeforeEach
+  void setUp() {
+
+    testUser = User.builder()
+        .id(1L)
+        .email("email@email.com")
+        .password("password111")
+        .phone("010-1234-5678")
+        .name("테스트")
+        .profileImageUrl("/uploads/profile/image.png")
+        .build();
+
+    UserDetails userDetails = withUsername(testUser.getEmail()).password(
+        testUser.getPassword()).authorities(Collections.emptyList()).build();
+
+    auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+  }
+
+  @Test
+  @DisplayName("내 정보 조회가 성공한다.")
+  void get_my_info_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    // when
+    UserResponseDto responseDto = userService.getMyInfo(auth);
+    // then
+    assertEquals(testUser.getEmail(), responseDto.email());
+  }
+
+  @Test
+  @DisplayName("특정 회원 조회에 성공한다.")
+  void get_user_info_success() {
+    // given
+    when(userQueryService.findById(testUser.getId())).thenReturn(testUser);
+    // when
+    UserResponseDto responseDto = userService.getUser(testUser.getId());
+    // then
+    assertEquals(testUser.getEmail(), responseDto.email());
+  }
+
+  @Test
+  @DisplayName("비밀번호 변경이 성공한다.")
+  void change_password_success() {
+    // given
+    ChangePasswordDto changePasswordDto = new ChangePasswordDto("newPassword",
+        testUser.getPassword());
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(passwordEncoder.matches(changePasswordDto.confirmPassword(),
+        testUser.getPassword())).thenReturn(true);
+    when(passwordEncoder.encode(changePasswordDto.password())).thenReturn("newEncryptedPassword");
+    // when
+    userService.changePassword(auth, changePasswordDto);
+    // then
+    assertEquals("newEncryptedPassword", testUser.getPassword());
+  }
+
+  @Test
+  @DisplayName("현재 비밀번호가 틀리면 비밀번호 변경이 실패한다.")
+  void change_password_failure_invalid_password() {
+    // given
+    ChangePasswordDto changePasswordDto = new ChangePasswordDto("newPassword",
+        "wrongPassword");
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(passwordEncoder.matches(changePasswordDto.confirmPassword(),
+        testUser.getPassword())).thenReturn(false);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> userService.changePassword(auth, changePasswordDto));
+    // then
+    assertEquals(REQUEST_VALIDATION_FAIL, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("프로필 이미지 수정에 성공한다.")
+  void update_profile_image_success() {
+    // given
+    String newImageUrl = "/uploads/profile/newImage.png";
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(imageService.updateProfileImage(eq(testUser.getProfileImageUrl()),
+        any(MultipartFile.class))).thenReturn(newImageUrl);
+    // when
+    byte[] content = "dummy".getBytes(UTF_8);
+    MockMultipartFile file = new MockMultipartFile("image", "dummy.png", "image/png", content);
+    String returnUrl = userService.updateProfileImage(auth, file);
+    // then
+    assertEquals(newImageUrl, returnUrl);
+    assertEquals(testUser.getProfileImageUrl(), returnUrl);
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- user 관련: 회원조회, 수정, 프로필 이미지 구현
## 📌 작업 이유 (Why)
- 회원 조회 기능 구현
- 프로필 이미지 업로드 및 프로필 이미지 수정
## ✨ 변경 사항 (Changes)
- DateTime Format 을 yyyy-MM-dd HH:mm:ss 형식으로 전역 처리
- 브라우저 에서 접근할 수 있도록 WebConfig 설정
- 회원가입 시 프로필 이미지를 등록할 수 있도록 구현
- 이미지는 로컬 스토리지에 저장
- 이미지 파일 형식이 올바르지 않으면 저장 불가능
- 이미지 파일 용량이 5MB 초과 시 저장 불가능
- 이미지 저장 시 Thumbnailator 라이브러리르 추가하여 리사이징 구현
- 내 정보 조회 로직 추가
- 비밀번호 재설정 로직 추가
- 특정 회원 조회 로직 추가
- 프로필 이미지 수정 로직 추가
## ✅ 테스트 (Tests)
- [ ] 내 정보 조회가 성공한다.
- [ ] 특정 회원 조회에 성공한다.
- [ ] 비밀번호 변경이 성공한다.
- [ ] 현재 비밀번호가 틀리면 비밀번호 변경이 실패한다.
- [ ] 프로필 이미지 수정에 성공한다.