### PR TITLE
feat: todo 관련 - 할일 생성, 조회, 수정 및 MyBatis 동적쿼리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.8'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+    implementation group: 'com.github.pagehelper', name: 'pagehelper-spring-boot-starter', version: '1.4.6'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/todo/config/JacksonConfig.java
+++ b/src/main/java/com/todo/config/JacksonConfig.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -21,8 +22,10 @@ public class JacksonConfig {
     ObjectMapper objectMapper = new ObjectMapper();
 
     JavaTimeModule javaTimeModule = new JavaTimeModule();
-    javaTimeModule.addSerializer(LocalDateTime.class,
-        new LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(formatter));
+    javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(formatter));
 
     objectMapper.registerModule(javaTimeModule);
 

--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -22,11 +22,13 @@ public enum ErrorCode {
 
   // 404 NOT FOUND
   USER_NOT_FOUND(NOT_FOUND, "회원을 찾을 수 없습니다."),
+  TODO_NOT_FOUND(NOT_FOUND, "할일을 찾을 수 없습니다."),
 
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT
   ALREADY_EXISTS_EMAIL(CONFLICT, "이미 존재하는 메일입니다."),
+  VERSION_CONFLICT(CONFLICT, "동시성 충돌이 발생했습니다. 다시 시도해 주세요."),
 
   // 500 INTERNAL SEVER ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/todo/todo/controller/TodoController.java
+++ b/src/main/java/com/todo/todo/controller/TodoController.java
@@ -1,0 +1,63 @@
+package com.todo.todo.controller;
+
+import com.github.pagehelper.PageInfo;
+import com.todo.todo.dto.TodoDto;
+import com.todo.todo.dto.TodoFilterResponseDto;
+import com.todo.todo.dto.TodoResponseDto;
+import com.todo.todo.dto.TodoUpdateDto;
+import com.todo.todo.service.TodoService;
+import com.todo.todo.type.TodoCategory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/todos")
+@RequiredArgsConstructor
+public class TodoController {
+
+  private final TodoService todoService;
+
+  @PostMapping
+  public ResponseEntity<Void> createTodo(Authentication auth,
+      @RequestBody @Valid TodoDto todoDto) {
+
+    todoService.createTodo(auth, todoDto);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<PageInfo<TodoFilterResponseDto>> getTodos(Authentication auth,
+      @RequestParam(value = "category", required = false) TodoCategory todoCategory,
+      @RequestParam(value = "priority", required = false) Boolean isPriority,
+      @RequestParam(value = "completed", required = false) Boolean isCompleted,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    return ResponseEntity.ok(todoService.getTodos(auth, todoCategory, isPriority, isCompleted, page, pageSize));
+  }
+
+  @GetMapping("/{todoId}")
+  public ResponseEntity<TodoResponseDto> getTodoDetail(Authentication auth, @PathVariable Long todoId) {
+
+    return ResponseEntity.ok(todoService.getTodoDetail(auth, todoId));
+  }
+
+  @PutMapping("/{todoId}")
+  public ResponseEntity<TodoResponseDto> updateTodo(Authentication auth,
+      @PathVariable Long todoId,
+  @RequestBody @Valid TodoUpdateDto todoUpdateDto) {
+
+    return ResponseEntity.ok(todoService.updateTodo(auth, todoId, todoUpdateDto));
+  }
+}

--- a/src/main/java/com/todo/todo/dto/TodoDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoDto.java
@@ -1,0 +1,25 @@
+package com.todo.todo.dto;
+
+import com.todo.todo.type.TodoCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record TodoDto(
+
+    Long projectId,
+
+    @NotBlank(message = "제목은 필수 입력입니다.")
+    String title,
+
+    String description,
+
+    @NotNull(message = "카테고리를 설정해 주세요.")
+    TodoCategory todoCategory,
+
+    boolean isPriority,
+
+    LocalDateTime dueDate
+) {
+
+}

--- a/src/main/java/com/todo/todo/dto/TodoFilterRequestDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoFilterRequestDto.java
@@ -1,0 +1,13 @@
+package com.todo.todo.dto;
+
+import com.todo.todo.type.TodoCategory;
+
+public record TodoFilterRequestDto(
+
+    Long authorId,
+    TodoCategory todoCategory,
+    Boolean isPriority,
+    Boolean isCompleted
+) {
+
+}

--- a/src/main/java/com/todo/todo/dto/TodoFilterResponseDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoFilterResponseDto.java
@@ -1,0 +1,33 @@
+package com.todo.todo.dto;
+
+import com.todo.todo.entity.Todo;
+import com.todo.todo.type.TodoCategory;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record TodoFilterResponseDto(
+
+    Long id,
+    Long authorId,
+    Long projectId,
+    String title,
+    TodoCategory todoCategory,
+    boolean isCompleted,
+    boolean isPriority,
+    LocalDateTime dueDate
+) {
+
+  public static TodoFilterResponseDto fromEntity(Todo todo) {
+
+    return TodoFilterResponseDto.builder()
+        .id(todo.getId())
+        .authorId(todo.getAuthor().getId())
+        .title(todo.getTitle())
+        .todoCategory(todo.getTodoCategory())
+        .isCompleted(todo.isCompleted())
+        .isPriority(todo.isPriority())
+        .dueDate(todo.getDueDate())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/todo/dto/TodoResponseDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoResponseDto.java
@@ -1,0 +1,40 @@
+package com.todo.todo.dto;
+
+import com.todo.todo.entity.Todo;
+import com.todo.todo.type.TodoCategory;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record TodoResponseDto(
+
+    Long id,
+    Long authorId,
+    Long projectId,
+    String title,
+    String description,
+    TodoCategory todoCategory,
+    boolean isCompleted,
+    boolean isPriority,
+    Long version,
+    LocalDateTime dueDate,
+    LocalDateTime createdAt
+) {
+
+  public static TodoResponseDto fromEntity(Todo todo) {
+
+    return TodoResponseDto.builder()
+        .id(todo.getId())
+        .authorId(todo.getAuthor().getId())
+        .projectId(todo.getProjectId())
+        .title(todo.getTitle())
+        .description(todo.getDescription())
+        .todoCategory(todo.getTodoCategory())
+        .isCompleted(todo.isCompleted())
+        .isPriority(todo.isPriority())
+        .version(todo.getVersion())
+        .dueDate(todo.getDueDate())
+        .createdAt(todo.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/todo/dto/TodoUpdateDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoUpdateDto.java
@@ -1,0 +1,27 @@
+package com.todo.todo.dto;
+
+import com.todo.todo.type.TodoCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record TodoUpdateDto(
+
+    Long projectId,
+
+    @NotBlank(message = "제목은 필수 입력입니다.")
+    String title,
+
+    String description,
+
+    @NotNull(message = "카테고리를 설정해 주세요.")
+    TodoCategory todoCategory,
+
+    boolean isPriority,
+
+    boolean isCompleted,
+
+    LocalDateTime dueDate
+) {
+
+}

--- a/src/main/java/com/todo/todo/entity/Todo.java
+++ b/src/main/java/com/todo/todo/entity/Todo.java
@@ -1,0 +1,94 @@
+package com.todo.todo.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.todo.dto.TodoDto;
+import com.todo.todo.dto.TodoUpdateDto;
+import com.todo.todo.type.TodoCategory;
+import com.todo.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Table(name = "todos")
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Todo {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "author_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private User author;
+
+  private Long projectId;
+
+  @Column(nullable = false)
+  private String title;
+
+  private String description;
+
+  @Enumerated(STRING)
+  private TodoCategory todoCategory;
+
+  private boolean isCompleted;
+
+  private boolean isPriority;
+
+  @Version
+  private Long version;
+
+  private LocalDateTime dueDate;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  public static Todo of(User author, TodoDto todoDto) {
+
+    return Todo.builder()
+        .author(author)
+        .projectId(todoDto.projectId())
+        .title(todoDto.title())
+        .description(todoDto.description())
+        .todoCategory(todoDto.todoCategory())
+        .isCompleted(false)
+        .isPriority(todoDto.isPriority())
+        .version(1L)
+        .dueDate(todoDto.dueDate())
+        .build();
+  }
+
+  public void update(TodoUpdateDto todoUpdateDto) {
+    projectId = todoUpdateDto.projectId();
+    title = todoUpdateDto.title();
+    description = todoUpdateDto.description();
+    todoCategory = todoUpdateDto.todoCategory();
+    isPriority = todoUpdateDto.isPriority();
+    isCompleted = todoUpdateDto.isCompleted();
+    dueDate = todoUpdateDto.dueDate();
+  }
+}

--- a/src/main/java/com/todo/todo/mapper/TodoMapper.java
+++ b/src/main/java/com/todo/todo/mapper/TodoMapper.java
@@ -1,0 +1,12 @@
+package com.todo.todo.mapper;
+
+import com.todo.todo.dto.TodoFilterRequestDto;
+import com.todo.todo.entity.Todo;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface TodoMapper {
+
+  List<Todo> filterTodos(TodoFilterRequestDto todoFilterRequestDto);
+}

--- a/src/main/java/com/todo/todo/repository/TodoRepository.java
+++ b/src/main/java/com/todo/todo/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package com.todo.todo.repository;
+
+import com.todo.todo.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/com/todo/todo/service/TodoQueryService.java
+++ b/src/main/java/com/todo/todo/service/TodoQueryService.java
@@ -1,0 +1,22 @@
+package com.todo.todo.service;
+
+import static com.todo.exception.ErrorCode.TODO_NOT_FOUND;
+
+import com.todo.exception.CustomException;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.repository.TodoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoQueryService {
+
+  private final TodoRepository todoRepository;
+
+  public Todo findById(Long id) {
+    return todoRepository.findById(id).orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/todo/todo/service/TodoService.java
+++ b/src/main/java/com/todo/todo/service/TodoService.java
@@ -1,0 +1,113 @@
+package com.todo.todo.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.exception.ErrorCode.VERSION_CONFLICT;
+
+import com.github.pagehelper.PageHelper;
+import com.github.pagehelper.PageInfo;
+import com.todo.exception.CustomException;
+import com.todo.todo.dto.TodoDto;
+import com.todo.todo.dto.TodoFilterRequestDto;
+import com.todo.todo.dto.TodoFilterResponseDto;
+import com.todo.todo.dto.TodoResponseDto;
+import com.todo.todo.dto.TodoUpdateDto;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.mapper.TodoMapper;
+import com.todo.todo.repository.TodoRepository;
+import com.todo.todo.type.TodoCategory;
+import com.todo.user.service.UserQueryService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoService {
+
+  private final TodoRepository todoRepository;
+
+  private final UserQueryService userQueryService;
+
+  private final TodoQueryService todoQueryService;
+
+  private final TodoMapper todoMapper;
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Transactional
+  public void createTodo(Authentication auth, TodoDto todoDto) {
+
+    todoRepository.save(Todo.of(userQueryService.findByEmail(auth.getName()), todoDto));
+  }
+
+  public PageInfo<TodoFilterResponseDto> getTodos(Authentication auth,
+      TodoCategory todoCategory, Boolean isPriority, Boolean isCompleted,
+      int page, int pageSize) {
+
+    Long authorId = userQueryService.findByEmail(auth.getName()).getId();
+
+    TodoFilterRequestDto todoFilterRequestDto = new TodoFilterRequestDto(
+        authorId,
+        todoCategory,
+        isPriority,
+        isCompleted);
+
+    PageHelper.startPage(page, pageSize);
+    List<Todo> todos = todoMapper.filterTodos(todoFilterRequestDto);
+    PageInfo<Todo> todoPageInfo = new PageInfo<>(todos);
+
+    List<TodoFilterResponseDto> dtoList = todos.stream()
+        .map(TodoFilterResponseDto::fromEntity).toList();
+
+    PageInfo<TodoFilterResponseDto> result = new PageInfo<>();
+    result.setList(dtoList);
+    result.setPageNum(todoPageInfo.getPageNum());
+    result.setPageSize(todoPageInfo.getPageSize());
+    result.setTotal(todoPageInfo.getTotal());
+    result.setPages(todoPageInfo.getPages());
+
+    return result;
+  }
+
+  public TodoResponseDto getTodoDetail(Authentication auth, Long todoId) {
+
+    Long authorId = userQueryService.findByEmail(auth.getName()).getId();
+
+    Todo todo = todoQueryService.findById(todoId);
+
+    if (!todo.getAuthor().getId().equals(authorId)) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    return TodoResponseDto.fromEntity(todo);
+  }
+
+  @Transactional
+  public TodoResponseDto updateTodo(Authentication auth, Long todoId,
+      TodoUpdateDto todoUpdateDto) {
+
+    Long authorId = userQueryService.findByEmail(auth.getName()).getId();
+
+    Todo todo = todoQueryService.findById(todoId);
+
+    if (!todo.getAuthor().getId().equals(authorId)) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    todo.update(todoUpdateDto);
+
+    try {
+      entityManager.flush();
+      return TodoResponseDto.fromEntity(todo);
+    } catch (OptimisticLockException e) {
+      throw new CustomException(VERSION_CONFLICT);
+    }
+  }
+}

--- a/src/main/java/com/todo/todo/type/TodoCategory.java
+++ b/src/main/java/com/todo/todo/type/TodoCategory.java
@@ -1,0 +1,5 @@
+package com.todo.todo.type;
+
+public enum TodoCategory {
+  WORK, INDIVIDUAL
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ jwt.refresh.expiration=604800000
 
 logging.level.org.hibernate.sql=info
 logging.level.org.hibernate.type.descriptor=trace
+
+mybatis.mapper-locations=classpath:mapper/**/*.xml
+mybatis.type-aliases-package=com.todo.todo.entity

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTO Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.todo.todo.mapper.TodoMapper">
+  <resultMap id="TodoResultMap" type="com.todo.todo.entity.Todo">
+    <id property="id" column="id"/>
+    <result property="projectId" column="project_id"/>
+    <result property="title" column="title"/>
+    <result property="description" column="description"/>
+    <result property="todoCategory" column="todo_category" javaType="com.todo.todo.type.TodoCategory"/>
+    <result property="isCompleted" column="is_completed"/>
+    <result property="isPriority" column="is_priority"/>
+    <result property="version" column="version"/>
+    <result property="dueDate" column="due_date"/>
+    <result property="createdAt" column="created_at"/>
+
+    <association property="author" javaType="com.todo.user.entity.User" column="id">
+      <id property="id" column="author_id"/>
+    </association>
+  </resultMap>
+  <select id="filterTodos" parameterType="com.todo.todo.dto.TodoFilterRequestDto" resultMap="TodoResultMap">
+    SELECT
+    t.id,
+    t.project_id,
+    t.title,
+    t.description,
+    t.todo_category,
+    t.is_completed,
+    t.is_priority,
+    t.version,
+    t.due_date,
+    t.created_at,
+    u.id as author_id
+    FROM todos t
+    LEFT JOIN users u ON t.author_id = u.id
+    <where>
+      AND author_id = #{authorId}
+      <if test="todoCategory != null">
+        AND todo_category = #{todoCategory}
+      </if>
+      <if test="isPriority != null">
+        AND is_priority = #{isPriority}
+      </if>
+      <if test="isCompleted != null">
+        AND is_completed = #{isCompleted}
+      </if>
+    </where>
+    ORDER BY t.created_at ASC
+  </select>
+</mapper>

--- a/src/test/java/com/todo/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/todo/todo/service/TodoServiceTest.java
@@ -1,0 +1,165 @@
+package com.todo.todo.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.todo.type.TodoCategory.INDIVIDUAL;
+import static com.todo.todo.type.TodoCategory.WORK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.pagehelper.PageInfo;
+import com.todo.exception.CustomException;
+import com.todo.todo.dto.TodoDto;
+import com.todo.todo.dto.TodoFilterRequestDto;
+import com.todo.todo.dto.TodoFilterResponseDto;
+import com.todo.todo.dto.TodoResponseDto;
+import com.todo.todo.dto.TodoUpdateDto;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.mapper.TodoMapper;
+import com.todo.todo.repository.TodoRepository;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+  @Mock
+  private TodoRepository todoRepository;
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private TodoQueryService todoQueryService;
+
+  @Mock
+  private TodoMapper todoMapper;
+
+  @Mock
+  private EntityManager entityManager;
+
+  @InjectMocks
+  private TodoService todoService;
+
+  private Authentication auth;
+  private User testUser;
+  private Todo todo;
+
+  @BeforeEach
+  void setUp() {
+    auth = new UsernamePasswordAuthenticationToken("test@mail.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@mail.com")
+        .build();
+
+    todo = Todo.builder()
+        .id(1L)
+        .author(testUser)
+        .projectId(null)
+        .title("제목")
+        .description("설명")
+        .todoCategory(INDIVIDUAL)
+        .isCompleted(false)
+        .isPriority(false)
+        .version(1L)
+        .dueDate(LocalDateTime.of(2025, 2, 11, 11, 0))
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    ReflectionTestUtils.setField(todoService, "entityManager", entityManager);
+  }
+
+  @Test
+  @DisplayName("할일 생성이 성공한다")
+  void create_todo_success() {
+    // given
+    TodoDto todoDto = new TodoDto(2L, "할일", "설명", WORK, true, LocalDateTime.now());
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    // when
+    todoService.createTodo(auth, todoDto);
+    // then
+    verify(todoRepository).save(any(Todo.class));
+  }
+
+  @Test
+  @DisplayName("할일 목록 조회가 성공한다")
+  void get_todo_success() {
+    // given
+    List<Todo> todoList = Collections.singletonList(todo);
+    when(todoMapper.filterTodos(any(TodoFilterRequestDto.class))).thenReturn(todoList);
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    // when
+    PageInfo<TodoFilterResponseDto> pageInfo = todoService.getTodos(auth, INDIVIDUAL, false, false,
+        1, 10);
+    // then
+    assertEquals(todo.getId(), pageInfo.getList().get(0).id());
+    assertEquals(todo.getTitle(), pageInfo.getList().get(0).title());
+  }
+
+  @Test
+  @DisplayName("할일 상세 조회가 성공한다")
+  void get_todo_detail_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    // when
+    TodoResponseDto responseDto = todoService.getTodoDetail(auth, todo.getId());
+    // then
+    assertEquals(todo.getId(), responseDto.id());
+    assertEquals(testUser.getId(), responseDto.authorId());
+  }
+
+  @Test
+  @DisplayName("작성자가 아니면 할일 상세 조회가 실패한다")
+  void get_todo_detail_failure_forbidden() {
+    // given
+    User otherUser = User.builder().id(2L).email("other@email.com").build();
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(
+        Todo.builder().id(1L).author(otherUser).build());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> todoService.getTodoDetail(auth, todo.getId()));
+    // then
+    assertEquals(FORBIDDEN, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("할일 수정이 성공한다")
+  void update_todo_success() {
+    // given
+    TodoUpdateDto updateDto = new TodoUpdateDto(
+        null,
+        "수정",
+        "설명",
+        WORK,
+        false,
+        true,
+        LocalDateTime.of(2025, 2, 17, 0, 0));
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    // when
+    TodoResponseDto responseDto = todoService.updateTodo(auth, todo.getId(), updateDto);
+    // then
+    assertEquals("수정", responseDto.title());
+    assertEquals(LocalDateTime.of(2025, 2, 17, 0, 0), responseDto.dueDate());
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- todo 관련: 할일 생성, 조회, 수정 및 MyBatis 동적쿼리 구현
## 📌 작업 이유 (Why)
- 서비스의 핵심 기능인 할일 구현
- 복잡한 동적 쿼리를 구현하기 위해 MyBatis 사용
## ✨ 변경 사항 (Changes)
- 날짜 정보 역직렬화 설정 추가
- 할일 생성 로직 추가
- 할일은 제목과 설명 등으로 구성
- 할일에 완료여부 설정 가능
- 할일에 중요 설정 가능
- 할일에 마감일 설정 가능
- 할일은 개인, 업무에 따라 카테고리 별로 구분 가능
- 할일 목록 조회 로직 추가
- 내가 생성한 할일이 아니면 조회 불가능
- 할일 목록은 파라미터 값들의 입력 여부에 따라 동적 쿼리 구현
- MyBatis 를 활용해 필터링 동적 쿼리 구현
- 할일 목록 페이징 처리
- 할일 상세 조회 로직 추가
- 할일 수정 로직 추가
할일은 버전별로 관리되며, 동시성 이슈를 해결하기 위해 현재 버전이 다를 경우 수정이 불가능
## ✅ 테스트 (Tests)
- [ ] 할일 생성이 성공한다
- [ ] 할일 목록 조회가 성공한다
- [ ] 할일 상세 조회가 성공한다
- [ ] 작성자가 아니면 할일 상세 조회가 실패한다
- [ ] 할일 수정이 성공한다