### PR TITLE
feat: project 관련 - 프로젝트 생성, 조회, 수정 및 할일 로직 일부 변경

### DIFF
--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   // 404 NOT FOUND
   USER_NOT_FOUND(NOT_FOUND, "회원을 찾을 수 없습니다."),
   TODO_NOT_FOUND(NOT_FOUND, "할일을 찾을 수 없습니다."),
+  PROJECT_NOT_FOUND(NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
 
   // 408 REQUEST TIMEOUT
 

--- a/src/main/java/com/todo/project/controller/ProjectController.java
+++ b/src/main/java/com/todo/project/controller/ProjectController.java
@@ -1,0 +1,57 @@
+package com.todo.project.controller;
+
+import com.todo.project.dto.ProjectDto;
+import com.todo.project.dto.ProjectPageResponseDto;
+import com.todo.project.dto.ProjectResponseDto;
+import com.todo.project.service.ProjectService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+@RequiredArgsConstructor
+public class ProjectController {
+
+  private final ProjectService projectService;
+
+  @PostMapping
+  public ResponseEntity<Void> createProject(Authentication auth,
+      @RequestBody ProjectDto projectDto) {
+
+    projectService.createProject(auth, projectDto);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<ProjectPageResponseDto>> getProjects(Authentication auth,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    return ResponseEntity.ok(projectService.getProjects(auth, page, pageSize));
+  }
+
+  @GetMapping("/{projectId}")
+  public ResponseEntity<ProjectResponseDto> getProjectDetail(Authentication auth,
+      @PathVariable Long projectId) {
+
+    return ResponseEntity.ok(projectService.getProjectDetail(auth, projectId));
+  }
+
+  @PutMapping("/{projectId}")
+  public ResponseEntity<ProjectResponseDto> updateProject(Authentication auth,
+      @PathVariable Long projectId, @RequestBody ProjectDto projectDto) {
+
+    return ResponseEntity.ok(projectService.updateProject(auth, projectId, projectDto));
+  }
+}

--- a/src/main/java/com/todo/project/dto/ProjectDto.java
+++ b/src/main/java/com/todo/project/dto/ProjectDto.java
@@ -1,0 +1,12 @@
+package com.todo.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProjectDto(
+
+    @NotBlank(message = "프로젝트명은 필수 입력입니다.")
+    String name,
+    String description
+) {
+
+}

--- a/src/main/java/com/todo/project/dto/ProjectPageResponseDto.java
+++ b/src/main/java/com/todo/project/dto/ProjectPageResponseDto.java
@@ -1,0 +1,9 @@
+package com.todo.project.dto;
+
+public record ProjectPageResponseDto(
+
+    Long id,
+    String name
+) {
+
+}

--- a/src/main/java/com/todo/project/dto/ProjectResponseDto.java
+++ b/src/main/java/com/todo/project/dto/ProjectResponseDto.java
@@ -1,0 +1,27 @@
+package com.todo.project.dto;
+
+import com.todo.project.entity.Project;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ProjectResponseDto(
+
+    Long id,
+    String ownerName,
+    String name,
+    String description,
+    LocalDateTime createdAt
+) {
+
+  public static ProjectResponseDto fromEntity(Project project) {
+
+    return ProjectResponseDto.builder()
+        .id(project.getId())
+        .ownerName(project.getOwner().getName())
+        .name(project.getName())
+        .description(project.getDescription())
+        .createdAt(project.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/project/entity/Project.java
+++ b/src/main/java/com/todo/project/entity/Project.java
@@ -1,0 +1,64 @@
+package com.todo.project.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.project.dto.ProjectDto;
+import com.todo.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "projects")
+public class Project {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "owner_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private User owner;
+
+  @Column(nullable = false)
+  private String name;
+
+  private String description;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  public static Project of(User owner, ProjectDto projectDto) {
+
+    return Project.builder()
+        .owner(owner)
+        .name(projectDto.name())
+        .description(projectDto.description())
+        .build();
+  }
+
+  public void update(ProjectDto projectDto) {
+    name = projectDto.name();
+    description = projectDto.description();
+  }
+}

--- a/src/main/java/com/todo/project/repository/ProjectRepository.java
+++ b/src/main/java/com/todo/project/repository/ProjectRepository.java
@@ -1,0 +1,12 @@
+package com.todo.project.repository;
+
+import com.todo.project.entity.Project;
+import com.todo.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+  Page<Project> findByOwner(User owner, Pageable pageable);
+}

--- a/src/main/java/com/todo/project/service/ProjectQueryService.java
+++ b/src/main/java/com/todo/project/service/ProjectQueryService.java
@@ -1,0 +1,23 @@
+package com.todo.project.service;
+
+import static com.todo.exception.ErrorCode.PROJECT_NOT_FOUND;
+
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProjectQueryService {
+
+  private final ProjectRepository projectRepository;
+
+  public Project findById(Long id) {
+
+    return projectRepository.findById(id).orElseThrow(() -> new CustomException(PROJECT_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/todo/project/service/ProjectService.java
+++ b/src/main/java/com/todo/project/service/ProjectService.java
@@ -1,0 +1,75 @@
+package com.todo.project.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+
+import com.todo.exception.CustomException;
+import com.todo.project.dto.ProjectDto;
+import com.todo.project.dto.ProjectPageResponseDto;
+import com.todo.project.dto.ProjectResponseDto;
+import com.todo.project.entity.Project;
+import com.todo.project.repository.ProjectRepository;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProjectService {
+
+  private final ProjectRepository projectRepository;
+
+  private final UserQueryService userQueryService;
+
+  private final ProjectQueryService projectQueryService;
+
+  @Transactional
+  public void createProject(Authentication auth, ProjectDto projectDto) {
+
+    projectRepository.save(Project.of(userQueryService.findByEmail(auth.getName()), projectDto));
+  }
+
+  public Page<ProjectPageResponseDto> getProjects(Authentication auth, int page, int pageSize) {
+
+    User owner = userQueryService.findByEmail(auth.getName());
+
+    Page<Project> projects = projectRepository.findByOwner(owner,
+        PageRequest.of(page - 1, pageSize));
+
+    return projects.map(project -> new ProjectPageResponseDto(project.getId(), project.getName()));
+  }
+
+  public ProjectResponseDto getProjectDetail(Authentication auth, Long projectId) {
+
+    Long ownerId = userQueryService.findByEmail(auth.getName()).getId();
+
+    Project project = projectQueryService.findById(projectId);
+
+    if (!project.getOwner().getId().equals(ownerId)) {
+      throw new CustomException(FORBIDDEN);
+    }
+    return ProjectResponseDto.fromEntity(project);
+  }
+
+  @Transactional
+  public ProjectResponseDto updateProject(Authentication auth, Long projectId,
+      ProjectDto projectDto) {
+
+    Long ownerId = userQueryService.findByEmail(auth.getName()).getId();
+
+    Project project = projectQueryService.findById(projectId);
+
+    if (!project.getOwner().getId().equals(ownerId)) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    project.update(projectDto);
+
+    return ProjectResponseDto.fromEntity(project);
+  }
+}

--- a/src/main/java/com/todo/todo/controller/TodoController.java
+++ b/src/main/java/com/todo/todo/controller/TodoController.java
@@ -38,17 +38,21 @@ public class TodoController {
 
   @GetMapping
   public ResponseEntity<PageInfo<TodoFilterResponseDto>> getTodos(Authentication auth,
+      @RequestParam(value = "projectId", required = false) Long projectId,
       @RequestParam(value = "category", required = false) TodoCategory todoCategory,
       @RequestParam(value = "priority", required = false) Boolean isPriority,
       @RequestParam(value = "completed", required = false) Boolean isCompleted,
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
 
-    return ResponseEntity.ok(todoService.getTodos(auth, todoCategory, isPriority, isCompleted, page, pageSize));
+    return ResponseEntity.ok(
+        todoService.getTodos(auth, projectId, todoCategory, isPriority, isCompleted,
+            page, pageSize));
   }
 
   @GetMapping("/{todoId}")
-  public ResponseEntity<TodoResponseDto> getTodoDetail(Authentication auth, @PathVariable Long todoId) {
+  public ResponseEntity<TodoResponseDto> getTodoDetail(Authentication auth,
+      @PathVariable Long todoId) {
 
     return ResponseEntity.ok(todoService.getTodoDetail(auth, todoId));
   }
@@ -56,7 +60,7 @@ public class TodoController {
   @PutMapping("/{todoId}")
   public ResponseEntity<TodoResponseDto> updateTodo(Authentication auth,
       @PathVariable Long todoId,
-  @RequestBody @Valid TodoUpdateDto todoUpdateDto) {
+      @RequestBody @Valid TodoUpdateDto todoUpdateDto) {
 
     return ResponseEntity.ok(todoService.updateTodo(auth, todoId, todoUpdateDto));
   }

--- a/src/main/java/com/todo/todo/dto/TodoFilterRequestDto.java
+++ b/src/main/java/com/todo/todo/dto/TodoFilterRequestDto.java
@@ -5,6 +5,7 @@ import com.todo.todo.type.TodoCategory;
 public record TodoFilterRequestDto(
 
     Long authorId,
+    Long projectId,
     TodoCategory todoCategory,
     Boolean isPriority,
     Boolean isCompleted

--- a/src/main/java/com/todo/todo/service/TodoService.java
+++ b/src/main/java/com/todo/todo/service/TodoService.java
@@ -48,13 +48,14 @@ public class TodoService {
   }
 
   public PageInfo<TodoFilterResponseDto> getTodos(Authentication auth,
-      TodoCategory todoCategory, Boolean isPriority, Boolean isCompleted,
+      Long projectId, TodoCategory todoCategory, Boolean isPriority, Boolean isCompleted,
       int page, int pageSize) {
 
     Long authorId = userQueryService.findByEmail(auth.getName()).getId();
 
     TodoFilterRequestDto todoFilterRequestDto = new TodoFilterRequestDto(
         authorId,
+        projectId,
         todoCategory,
         isPriority,
         isCompleted);

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -36,14 +36,17 @@
     LEFT JOIN users u ON t.author_id = u.id
     <where>
       AND author_id = #{authorId}
+      <if test="projectId != null">
+        AND t.project_id = #{projcetId}
+      </if>
       <if test="todoCategory != null">
-        AND todo_category = #{todoCategory}
+        AND t.todo_category = #{todoCategory}
       </if>
       <if test="isPriority != null">
-        AND is_priority = #{isPriority}
+        AND t.is_priority = #{isPriority}
       </if>
       <if test="isCompleted != null">
-        AND is_completed = #{isCompleted}
+        AND t.is_completed = #{isCompleted}
       </if>
     </where>
     ORDER BY t.created_at ASC

--- a/src/test/java/com/todo/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/todo/project/service/ProjectServiceTest.java
@@ -1,0 +1,137 @@
+package com.todo.project.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.exception.CustomException;
+import com.todo.project.dto.ProjectDto;
+import com.todo.project.dto.ProjectPageResponseDto;
+import com.todo.project.dto.ProjectResponseDto;
+import com.todo.project.entity.Project;
+import com.todo.project.repository.ProjectRepository;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+  @Mock
+  private ProjectRepository projectRepository;
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private ProjectQueryService projectQueryService;
+
+  @InjectMocks
+  private ProjectService projectService;
+
+  private Authentication auth;
+  private User testUser;
+  private Project testProject;
+
+  @BeforeEach
+  void setUp() {
+    auth = new UsernamePasswordAuthenticationToken("test@test.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .name("이름")
+        .build();
+
+    testProject = Project.builder()
+        .id(1L)
+        .owner(testUser)
+        .name("프로젝트")
+        .createdAt(LocalDateTime.now())
+        .build();
+  }
+
+  @Test
+  @DisplayName("프로젝트 생성이 성공한다")
+  void creat_project_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    // when
+    projectService.createProject(auth, new ProjectDto("프로젝트", null));
+    // then
+    verify(projectRepository).save(any(Project.class));
+  }
+
+  @Test
+  @DisplayName("프로젝트 목록 조회가 성공한다")
+  void get_projects_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(projectRepository.findByOwner(testUser, PageRequest.of(0, 10))).thenReturn(
+        new PageImpl<>(List.of(testProject)));
+    // when
+    Page<ProjectPageResponseDto> projects = projectService.getProjects(auth, 1, 10);
+    // then
+    assertEquals(testProject.getId(), projects.getContent().get(0).id());
+    assertEquals(testProject.getName(), projects.getContent().get(0).name());
+  }
+
+  @Test
+  @DisplayName("프로젝트 상세 조회가 성공한다")
+  void get_project_detail_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(projectQueryService.findById(1L)).thenReturn(testProject);
+    // when
+    ProjectResponseDto projectResponseDto = projectService.getProjectDetail(auth, 1L);
+    // then
+    assertEquals(testProject.getId(), projectResponseDto.id());
+    assertEquals(testProject.getName(), projectResponseDto.name());
+    assertEquals(testProject.getOwner().getName(), projectResponseDto.ownerName());
+  }
+
+  @Test
+  @DisplayName("소유자가 아니면 프로젝트 상세 조회가 실패한다")
+  void get_project_detail_failure_owner_mismatch() {
+    // given
+    User otherUser = User.builder().id(2L).email("other@email.com").build();
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(projectQueryService.findById(1L)).thenReturn(
+        Project.builder().id(2L).owner(otherUser).build()
+    );
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> projectService.getProjectDetail(auth, 1L));
+    // then
+    assertEquals(FORBIDDEN, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("프로젝트 수정이 성공한다")
+  void update_project_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(projectQueryService.findById(1L)).thenReturn(testProject);
+    // when
+    ProjectResponseDto projectResponseDto = projectService.updateProject(auth, 1L,
+        new ProjectDto("변경", null));
+    // then
+    assertEquals(projectResponseDto.name(), testProject.getName());
+  }
+}

--- a/src/test/java/com/todo/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/todo/todo/service/TodoServiceTest.java
@@ -107,7 +107,7 @@ class TodoServiceTest {
     when(todoMapper.filterTodos(any(TodoFilterRequestDto.class))).thenReturn(todoList);
     when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
     // when
-    PageInfo<TodoFilterResponseDto> pageInfo = todoService.getTodos(auth, INDIVIDUAL, false, false,
+    PageInfo<TodoFilterResponseDto> pageInfo = todoService.getTodos(auth, null, INDIVIDUAL, false, false,
         1, 10);
     // then
     assertEquals(todo.getId(), pageInfo.getList().get(0).id());


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- project 관련: 프로젝트 생성, 조회, 수정 및 할일 로직 일부 변경
## 📌 작업 이유 (Why)
- 특정 할일들을 모아둘 수 있는 프로젝트 구현
## ✨ 변경 사항 (Changes)
- 프로젝트 생성 구현
- 프로젝트 목록 조회 구현
- 프로젝트는 소유자가 아니면 조회 불가능
- 프로젝트 목록은 페이징 처리
- 페이징은 이전에 구현했던 PageHelper 와 방식을 동일하게 하기 위해 페이지를 0 부터 받지않고 1 부터 받는 것으로 구현
- 프로젝트 상세 조회 구현
- 프로젝트 수정 구현
- 프로젝트는 소유자가 아니면 수정 불가능
- 프로젝트에 속한 할일 목록을 조회하기 위해 할일 로직 일부 변경
- MyBatis 필터링 조건(projectId) 추가
## ✅ 테스트 (Tests)
- [ ] 프로젝트 생성이 성공한다
- [ ] 프로젝트 목록 조회가 성공한다
- [ ] 프로젝트 상세 조회가 성공한다
- [ ] 소유자가 아니면 프로젝트 상세 조회가 실패한다
- [ ] 프로젝트 수정이 성공한다