### PR TITLE
feat: collaborator 관련 - 협업자 추가, 수정, 삭제 및 협업자 역할 관리 로직

### DIFF
--- a/src/main/java/com/todo/collaborator/controller/CollaboratorController.java
+++ b/src/main/java/com/todo/collaborator/controller/CollaboratorController.java
@@ -1,0 +1,62 @@
+package com.todo.collaborator.controller;
+
+import com.todo.collaborator.dto.CollaboratorDto;
+import com.todo.collaborator.dto.CollaboratorsDto;
+import com.todo.collaborator.service.CollaboratorService;
+import com.todo.collaborator.type.RoleType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/projects")
+@RequiredArgsConstructor
+public class CollaboratorController {
+
+  private final CollaboratorService collaboratorService;
+
+  @PostMapping("/{projectId}/collaborators")
+  public ResponseEntity<Void> addCollaborator(Authentication auth,
+      @PathVariable("projectId") Long projectId,
+      @RequestBody CollaboratorDto collaboratorDto) {
+
+    collaboratorService.addCollaborator(auth, projectId, collaboratorDto);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{projectId}/collaborators")
+  public ResponseEntity<List<CollaboratorsDto>> getCollaborators(Authentication auth,
+      @PathVariable("projectId") Long projectId) {
+
+    return ResponseEntity.ok(collaboratorService.getCollaborators(auth, projectId));
+  }
+
+  @PutMapping("/{projectId}/collaborators/{collaboratorId}")
+  public ResponseEntity<List<CollaboratorsDto>> updateCollaborator(Authentication auth,
+      @PathVariable("projectId") Long projectId,
+      @PathVariable("collaboratorId") Long collaboratorId,
+      @RequestBody RoleType roleType) {
+
+    return ResponseEntity.ok(
+        collaboratorService.updateCollaborator(auth, projectId, collaboratorId, roleType));
+  }
+
+  @DeleteMapping("/{projectId}/collaborators/{collaboratorId}")
+  public ResponseEntity<List<CollaboratorsDto>> deleteCollaborator(Authentication auth,
+      @PathVariable("projectId") Long projectId,
+      @PathVariable("collaboratorId") Long collaboratorId) {
+
+    return ResponseEntity.ok(
+        collaboratorService.deleteCollaborator(auth, projectId, collaboratorId));
+  }
+}

--- a/src/main/java/com/todo/collaborator/dto/CollaboratorDto.java
+++ b/src/main/java/com/todo/collaborator/dto/CollaboratorDto.java
@@ -1,0 +1,11 @@
+package com.todo.collaborator.dto;
+
+import com.todo.collaborator.type.RoleType;
+
+public record CollaboratorDto(
+
+    Long collaboratorId,
+    RoleType roleType
+) {
+
+}

--- a/src/main/java/com/todo/collaborator/dto/CollaboratorsDto.java
+++ b/src/main/java/com/todo/collaborator/dto/CollaboratorsDto.java
@@ -1,0 +1,25 @@
+package com.todo.collaborator.dto;
+
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.type.RoleType;
+import lombok.Builder;
+
+@Builder
+public record CollaboratorsDto(
+
+    Long collaboratorId,
+    String name,
+    RoleType roleType,
+    boolean isConfirmed
+) {
+
+  public static CollaboratorsDto fromEntity(Collaborator collaborator) {
+
+    return CollaboratorsDto.builder()
+        .collaboratorId(collaborator.getId())
+        .name(collaborator.getCollaborator().getName())
+        .roleType(collaborator.getRoleType())
+        .isConfirmed(collaborator.isConfirmed())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/collaborator/entity/Collaborator.java
+++ b/src/main/java/com/todo/collaborator/entity/Collaborator.java
@@ -1,0 +1,63 @@
+package com.todo.collaborator.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.collaborator.type.RoleType;
+import com.todo.project.entity.Project;
+import com.todo.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "collaborators")
+public class Collaborator {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "collaborator_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private User collaborator;
+
+  @JoinColumn(name = "project_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private Project project;
+
+  @Enumerated(STRING)
+  private RoleType roleType;
+
+  private boolean isConfirmed;
+
+  public static Collaborator of(User invitedUser, Project project, RoleType roleType,
+      boolean isConfirmed) {
+
+    return Collaborator.builder()
+        .collaborator(invitedUser)
+        .project(project)
+        .roleType(roleType)
+        .isConfirmed(isConfirmed)
+        .build();
+  }
+
+  public void update(RoleType roleType) {
+
+    this.roleType = roleType;
+  }
+}

--- a/src/main/java/com/todo/collaborator/repository/CollaboratorRepository.java
+++ b/src/main/java/com/todo/collaborator/repository/CollaboratorRepository.java
@@ -1,0 +1,23 @@
+package com.todo.collaborator.repository;
+
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.type.RoleType;
+import com.todo.project.entity.Project;
+import com.todo.user.entity.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CollaboratorRepository extends JpaRepository<Collaborator, Long> {
+
+  boolean existsByProjectAndCollaboratorAndConfirmed(Project project, User collaborator, boolean confirmed);
+
+  List<Collaborator> findByProject(Project project);
+
+  @Query("SELECT DISTINCT c.project FROM Collaborator c WHERE c.collaborator = :user AND c.isConfirmed = true")
+  List<Project> findProjectsByCollaborator(@Param("user") User user);
+
+  boolean existsByProjectAndCollaboratorAndRoleTypeAndConfirmed(Project project, User collaborator,
+      RoleType roleType, boolean confirmed);
+}

--- a/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
@@ -1,0 +1,48 @@
+package com.todo.collaborator.service;
+
+import static com.todo.exception.ErrorCode.COLLABORATOR_NOT_FOUND;
+
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.repository.CollaboratorRepository;
+import com.todo.collaborator.type.RoleType;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollaboratorQueryService {
+
+  private final CollaboratorRepository collaboratorRepository;
+
+  public boolean existsByProjectAndCollaboratorAndIsConfirmed(
+      Project project, User collaborator, boolean isConfirmed) {
+    return collaboratorRepository.existsByProjectAndCollaboratorAndConfirmed(
+        project, collaborator, isConfirmed);
+  }
+
+  public Collaborator findById(Long id) {
+    return collaboratorRepository.findById(id)
+        .orElseThrow(() -> new CustomException(COLLABORATOR_NOT_FOUND));
+  }
+
+  public List<Collaborator> findByProject(Project project) {
+    return collaboratorRepository.findByProject(project);
+  }
+
+  public List<Project> findProjectsByCollaborator(User user) {
+    return collaboratorRepository.findProjectsByCollaborator(user);
+  }
+
+  public boolean existsByProjectAndCollaboratorAndRoleTypeAndConfirmed(Project project, User user,
+      RoleType roleType, boolean isConfirmed) {
+
+    return collaboratorRepository.existsByProjectAndCollaboratorAndRoleTypeAndConfirmed(
+        project, user, roleType, isConfirmed);
+  }
+}

--- a/src/main/java/com/todo/collaborator/service/CollaboratorService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorService.java
@@ -1,0 +1,121 @@
+package com.todo.collaborator.service;
+
+import static com.todo.collaborator.type.RoleType.EDITOR;
+import static com.todo.exception.ErrorCode.ALREADY_EXISTS_USER;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+
+import com.todo.collaborator.dto.CollaboratorDto;
+import com.todo.collaborator.dto.CollaboratorsDto;
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.repository.CollaboratorRepository;
+import com.todo.collaborator.type.RoleType;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CollaboratorService {
+
+  private final UserQueryService userQueryService;
+
+  private final ProjectQueryService projectQueryService;
+
+  private final CollaboratorQueryService collaboratorQueryService;
+
+  private final CollaboratorRepository collaboratorRepository;
+
+  @Transactional
+  public void addCollaborator(Authentication auth, Long projectId,
+      CollaboratorDto collaboratorDto) {
+
+    Project project = findOwnerWithProject(auth, projectId);
+
+    registerOwner(project.getOwner(), project);
+
+    User invitedUser = userQueryService.findById(collaboratorDto.collaboratorId());
+
+    if (collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
+        project, invitedUser, true)) {
+      throw new CustomException(ALREADY_EXISTS_USER);
+    }
+
+    collaboratorRepository.save(
+        Collaborator.of(invitedUser, project, collaboratorDto.roleType(), false));
+  }
+
+  private void registerOwner(User owner, Project project) {
+
+    boolean ownerAlreadyExists = collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
+        project, owner, true);
+
+    if (!ownerAlreadyExists) {
+      collaboratorRepository.save(Collaborator.of(owner, project, EDITOR, true));
+    }
+  }
+
+  public List<CollaboratorsDto> getCollaborators(Authentication auth, Long projectId) {
+
+    User collaborator = userQueryService.findByEmail(auth.getName());
+
+    Project project = projectQueryService.findById(projectId);
+
+    if (!collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
+        project, collaborator, true)) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    List<Collaborator> collaborators = collaboratorQueryService.findByProject(project);
+
+    return collaborators.stream().map(CollaboratorsDto::fromEntity).collect(Collectors.toList());
+  }
+
+  @Transactional
+  public List<CollaboratorsDto> updateCollaborator(Authentication auth, Long projectId,
+      Long collaboratorId, RoleType roleType) {
+
+    Project project = findOwnerWithProject(auth, projectId);
+
+    Collaborator collaborator = collaboratorQueryService.findById(collaboratorId);
+
+    collaborator.update(roleType);
+
+    List<Collaborator> collaborators = collaboratorQueryService.findByProject(project);
+
+    return collaborators.stream().map(CollaboratorsDto::fromEntity).collect(Collectors.toList());
+  }
+
+  @Transactional
+  public List<CollaboratorsDto> deleteCollaborator(Authentication auth, Long projectId,
+      Long collaboratorId) {
+
+    Project project = findOwnerWithProject(auth, projectId);
+
+    collaboratorRepository.delete(collaboratorQueryService.findById(collaboratorId));
+
+    List<Collaborator> collaborators = collaboratorQueryService.findByProject(project);
+
+    return collaborators.stream().map(CollaboratorsDto::fromEntity).collect(Collectors.toList());
+  }
+
+  public Project findOwnerWithProject(Authentication auth, Long projectId) {
+
+    User owner = userQueryService.findByEmail(auth.getName());
+
+    Project project = projectQueryService.findById(projectId);
+
+    if (!project.getOwner().getId().equals(owner.getId())) {
+      throw new CustomException(FORBIDDEN);
+    }
+    return project;
+  }
+}

--- a/src/main/java/com/todo/collaborator/type/RoleType.java
+++ b/src/main/java/com/todo/collaborator/type/RoleType.java
@@ -1,0 +1,5 @@
+package com.todo.collaborator.type;
+
+public enum RoleType {
+  EDITOR, VIEWER
+}

--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -24,12 +24,14 @@ public enum ErrorCode {
   USER_NOT_FOUND(NOT_FOUND, "회원을 찾을 수 없습니다."),
   TODO_NOT_FOUND(NOT_FOUND, "할일을 찾을 수 없습니다."),
   PROJECT_NOT_FOUND(NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
+  COLLABORATOR_NOT_FOUND(NOT_FOUND, "협업자를 찾을 수 없습니다."),
 
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT
   ALREADY_EXISTS_EMAIL(CONFLICT, "이미 존재하는 메일입니다."),
   VERSION_CONFLICT(CONFLICT, "동시성 충돌이 발생했습니다. 다시 시도해 주세요."),
+  ALREADY_EXISTS_USER(CONFLICT, "이미 초대된 회원입니다."),
 
   // 500 INTERNAL SEVER ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/todo/project/service/ProjectService.java
+++ b/src/main/java/com/todo/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package com.todo.project.service;
 
 import static com.todo.exception.ErrorCode.FORBIDDEN;
 
+import com.todo.collaborator.service.CollaboratorQueryService;
 import com.todo.exception.CustomException;
 import com.todo.project.dto.ProjectDto;
 import com.todo.project.dto.ProjectPageResponseDto;
@@ -10,8 +11,14 @@ import com.todo.project.entity.Project;
 import com.todo.project.repository.ProjectRepository;
 import com.todo.user.entity.User;
 import com.todo.user.service.UserQueryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -28,6 +35,8 @@ public class ProjectService {
 
   private final ProjectQueryService projectQueryService;
 
+  private final CollaboratorQueryService collaboratorQueryService;
+
   @Transactional
   public void createProject(Authentication auth, ProjectDto projectDto) {
 
@@ -36,21 +45,32 @@ public class ProjectService {
 
   public Page<ProjectPageResponseDto> getProjects(Authentication auth, int page, int pageSize) {
 
-    User owner = userQueryService.findByEmail(auth.getName());
+    User user = userQueryService.findByEmail(auth.getName());
 
-    Page<Project> projects = projectRepository.findByOwner(owner,
+    Page<Project> ownerProject = projectRepository.findByOwner(user,
         PageRequest.of(page - 1, pageSize));
 
-    return projects.map(project -> new ProjectPageResponseDto(project.getId(), project.getName()));
+    List<Project> collaboratedProjects = collaboratorQueryService.findProjectsByCollaborator(user);
+
+    Set<Project> allProjectSet = new HashSet<>();
+    allProjectSet.addAll(ownerProject.getContent());
+    allProjectSet.addAll(collaboratedProjects);
+
+    return paginateResults(new ArrayList<>(allProjectSet), page, pageSize);
   }
 
   public ProjectResponseDto getProjectDetail(Authentication auth, Long projectId) {
 
-    Long ownerId = userQueryService.findByEmail(auth.getName()).getId();
+    User currentUser = userQueryService.findByEmail(auth.getName());
 
     Project project = projectQueryService.findById(projectId);
 
-    if (!project.getOwner().getId().equals(ownerId)) {
+    boolean isOwner = project.getOwner().getId().equals(currentUser.getId());
+    boolean isCollaboratorConfirmed = collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
+        project, currentUser, true);
+
+    if (!isOwner && !isCollaboratorConfirmed) {
+
       throw new CustomException(FORBIDDEN);
     }
     return ProjectResponseDto.fromEntity(project);
@@ -71,5 +91,22 @@ public class ProjectService {
     project.update(projectDto);
 
     return ProjectResponseDto.fromEntity(project);
+  }
+
+  private Page<ProjectPageResponseDto> paginateResults(List<Project> allProjectsList,
+      int page, int pageSize) {
+
+    int total = allProjectsList.size();
+    int fromIndex = (page - 1) * pageSize;
+    int toIndex = Math.min(fromIndex + pageSize, total);
+
+    List<Project> pageProjects = fromIndex < total ?
+        allProjectsList.subList(fromIndex, toIndex)
+        : Collections.emptyList();
+
+    List<ProjectPageResponseDto> dtoList = pageProjects.stream().map(
+        project -> new ProjectPageResponseDto(project.getId(), project.getName())).toList();
+
+    return new PageImpl<>(dtoList, PageRequest.of(page - 1, pageSize), total);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 
 jwt.secret=very-very-long-secure-secret-key-very-long
 # 5 Min
-jwt.access.expiration=300000
+jwt.access.expiration=60000
 # 7 Days
 jwt.refresh.expiration=604800000
 

--- a/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
+++ b/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
@@ -1,0 +1,151 @@
+package com.todo.collaborator.service;
+
+import static com.todo.collaborator.type.RoleType.EDITOR;
+import static com.todo.collaborator.type.RoleType.VIEWER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.collaborator.dto.CollaboratorDto;
+import com.todo.collaborator.dto.CollaboratorsDto;
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.repository.CollaboratorRepository;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class CollaboratorServiceTest {
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private ProjectQueryService projectQueryService;
+
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
+
+  @Mock
+  private CollaboratorRepository collaboratorRepository;
+
+  @InjectMocks
+  private CollaboratorService collaboratorService;
+
+  private User owner;
+  private User invitedUser;
+  private Project project;
+  private Collaborator collaboratorOwner;
+  private Collaborator collaboratorInvited;
+  private Authentication auth;
+
+  @BeforeEach
+  void setUp() {
+
+    owner = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .name("소유자")
+        .build();
+
+    invitedUser = User.builder()
+        .id(2L)
+        .email("test2@test.com")
+        .name("초대받음")
+        .build();
+
+    project = Project.builder()
+        .id(1L)
+        .owner(owner)
+        .name("프로젝트")
+        .build();
+
+    collaboratorOwner = Collaborator.of(owner, project, EDITOR, true);
+    collaboratorInvited = Collaborator.of(owner, project, VIEWER, false);
+
+    auth = new UsernamePasswordAuthenticationToken(owner.getEmail(), null);
+  }
+
+  @Test
+  @DisplayName("협업자 추가가 성공한다")
+  void add_collaborator_success() {
+    // given
+    when(userQueryService.findByEmail(owner.getEmail())).thenReturn(owner);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(userQueryService.findById(invitedUser.getId())).thenReturn(invitedUser);
+
+    CollaboratorDto collaboratorDto = new CollaboratorDto(invitedUser.getId(), VIEWER);
+    // when
+    collaboratorService.addCollaborator(auth, project.getId(), collaboratorDto);
+    // then
+    verify(collaboratorRepository).save(argThat(collaborator ->
+        collaborator.getCollaborator().getId().equals(owner.getId()) &&
+        collaborator.getRoleType() == EDITOR &&
+        collaborator.isConfirmed()));
+
+    verify(collaboratorRepository).save(argThat(collaborator ->
+        collaborator.getCollaborator().getId().equals(invitedUser.getId()) &&
+        collaborator.getRoleType() == VIEWER &&
+        !collaborator.isConfirmed()));
+  }
+
+  @Test
+  @DisplayName("협업자 목록 조회에 성공한다")
+  void get_collaborator_success() {
+    // given
+    when(userQueryService.findByEmail(owner.getEmail())).thenReturn(owner);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
+        project, owner, true)).thenReturn(true);
+
+    List<Collaborator> collaborators = List.of(collaboratorOwner, collaboratorInvited);
+    when(collaboratorQueryService.findByProject(project)).thenReturn(collaborators);
+    // when
+    List<CollaboratorsDto> result = collaboratorService.getCollaborators(auth, project.getId());
+    // then
+    assertEquals(2, result.size());
+  }
+
+  @Test
+  @DisplayName("협업자 수정에 성공한다")
+  void update_collaborator_success() {
+    // given
+    when(userQueryService.findByEmail(owner.getEmail())).thenReturn(owner);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(collaboratorQueryService.findById(collaboratorInvited.getId())).thenReturn(collaboratorInvited);
+
+    List<Collaborator> collaborators = List.of(collaboratorOwner, collaboratorInvited);
+    when(collaboratorQueryService.findByProject(project)).thenReturn(collaborators);
+    // when
+    collaboratorService.updateCollaborator(auth, project.getId(), collaboratorInvited.getId(), EDITOR);
+    // then
+    assertEquals(EDITOR, collaboratorInvited.getRoleType());
+  }
+
+  @Test
+  @DisplayName("협업자 삭제에 성공한다")
+  void delete_collaborator_success() {
+    // given
+    when(userQueryService.findByEmail(owner.getEmail())).thenReturn(owner);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(collaboratorQueryService.findById(collaboratorInvited.getId())).thenReturn(collaboratorInvited);
+
+    when(collaboratorQueryService.findByProject(project)).thenReturn(List.of(collaboratorOwner));
+    // when
+    List<CollaboratorsDto> result = collaboratorService.deleteCollaborator(auth, project.getId(), collaboratorInvited.getId());
+    // then
+    assertEquals(1, result.size());
+  }
+}

--- a/src/test/java/com/todo/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/todo/project/service/ProjectServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.todo.collaborator.service.CollaboratorQueryService;
 import com.todo.exception.CustomException;
 import com.todo.project.dto.ProjectDto;
 import com.todo.project.dto.ProjectPageResponseDto;
@@ -41,6 +42,9 @@ class ProjectServiceTest {
 
   @Mock
   private ProjectQueryService projectQueryService;
+
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
 
   @InjectMocks
   private ProjectService projectService;


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- collaborator 관련: 협업자 추가, 수정, 삭제 및 협업자 역할 관리 로직
## 📌 작업 이유 (Why)
- 할일을 모아놓은 프로젝트에 협업자 추가 로직 구현
## ✨ 변경 사항 (Changes)
- 협업자 추가 로직 구현
- 프로젝트의 소유자가 협업자를 초대할 수 있음
- 프로젝트의 소유자가 첫 번째 협업자를 초대할때 자신을 먼저 협업자에 등록됨
- 협업자의 역할을 부여하고 초대 가능
- 협업자 목록 조회 로직 구현
- 협업자 초대 승인을 받은 모든 인원은 프로젝트에 속한 협업자 조회 가능
- 협업자 역할 수정 로직 구현
- 초대받은 협업자는 초대 승인이 가능
- 협업자 삭제 로직 구현
- 프로젝트의 소유자는 협업자 삭제 가능
- 프로젝트에 속한 협업자는 프로젝트 목록 및 상세에 접근 가능
- 프로젝트에 속한 협업자는 프로젝트 내에 있는 할일에 접근 가능
- 수정권한이 있는 협업자는 할일 생성, 조회, 상세조회, 수정 가능
- 읽기권한이 있는 협업자는 조회, 상세조회만 가능
## ✅ 테스트 (Tests)
- [ ] 협업자 추가가 성공한다
- [ ] 협업자 목록 조회에 성공한다
- [ ] 협업자 수정에 성공한다
- [ ] 협업자 삭제에 성공한다