### PR TITLE
feat: comment 관련 로직 구현 - 댓글 추가, 조회, 수정, 소프트삭제

### DIFF
--- a/src/main/java/com/todo/collaborator/repository/CollaboratorRepository.java
+++ b/src/main/java/com/todo/collaborator/repository/CollaboratorRepository.java
@@ -21,4 +21,7 @@ public interface CollaboratorRepository extends JpaRepository<Collaborator, Long
 
   boolean existsByProjectAndCollaboratorAndRoleTypeAndConfirmType(Project project, User collaborator,
       RoleType roleType, ConfirmType confirmType);
+
+  Collaborator findByProjectAndCollaboratorAndConfirmType(Project project, User commentAuthor,
+      ConfirmType confirmType);
 }

--- a/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
@@ -46,4 +46,8 @@ public class CollaboratorQueryService {
     return collaboratorRepository.existsByProjectAndCollaboratorAndRoleTypeAndConfirmType(
         project, user, roleType, TRUE);
   }
+
+  public Collaborator findByProjectAndCollaboratorIsConfirmed(Project project, User commentAuthor) {
+    return collaboratorRepository.findByProjectAndCollaboratorAndConfirmType(project, commentAuthor, TRUE);
+  }
 }

--- a/src/main/java/com/todo/comment/controller/CommentController.java
+++ b/src/main/java/com/todo/comment/controller/CommentController.java
@@ -1,0 +1,59 @@
+package com.todo.comment.controller;
+
+import com.todo.comment.dto.CommentDto;
+import com.todo.comment.dto.CommentResponseDto;
+import com.todo.comment.dto.CommentUpdateDto;
+import com.todo.comment.service.CommentService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/todos")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @PostMapping("/{todoId}/comments")
+  public ResponseEntity<Void> addComment(Authentication auth,
+      @PathVariable(value = "todoId") Long todoId,
+      @RequestBody CommentDto commentDto) {
+
+    commentService.addComment(auth, todoId, commentDto);
+
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{todoId}/comments")
+  public ResponseEntity<Page<CommentResponseDto>> getComments(Authentication auth,
+      @PathVariable("todoId") Long todoId,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    Page<CommentResponseDto> comments = commentService.getComments(auth, todoId, page, pageSize);
+
+    return ResponseEntity.ok(comments);
+  }
+
+  @PutMapping("/{todoId}/comments/{commentId}")
+  public ResponseEntity<Void> updateComments(Authentication auth,
+      @PathVariable(value = "todoId") Long todoId,
+      @PathVariable(value = "commentId") Long commentId,
+      @RequestBody CommentUpdateDto commentUpdateDto) {
+
+    commentService.updateComments(auth, todoId, commentId, commentUpdateDto);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/todo/comment/dto/CommentDto.java
+++ b/src/main/java/com/todo/comment/dto/CommentDto.java
@@ -1,0 +1,9 @@
+package com.todo.comment.dto;
+
+public record CommentDto(
+
+    Long parentCommentId,
+    String content
+) {
+
+}

--- a/src/main/java/com/todo/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/todo/comment/dto/CommentResponseDto.java
@@ -1,0 +1,31 @@
+package com.todo.comment.dto;
+
+import com.todo.comment.entity.Comment;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CommentResponseDto(
+
+    Long commentId,
+    Long commentAuthorId,
+    String commentAuthorProfileImageUrl,
+    String commentAuthorName,
+    Long parentCommentId,
+    String content,
+    LocalDateTime createdAt
+) {
+
+  public static CommentResponseDto fromEntity(Comment comment) {
+
+    return CommentResponseDto.builder()
+        .commentId(comment.getId())
+        .commentAuthorId(comment.getCommentAuthor().getId())
+        .commentAuthorProfileImageUrl(comment.getCommentAuthor().getProfileImageUrl())
+        .commentAuthorName(comment.getCommentAuthor().getName())
+        .parentCommentId(comment.getParentCommentId())
+        .content(comment.getDeletedAt() == null ? comment.getContent() : "삭제된 댓글입니다.")
+        .createdAt(comment.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/comment/dto/CommentUpdateDto.java
+++ b/src/main/java/com/todo/comment/dto/CommentUpdateDto.java
@@ -1,0 +1,9 @@
+package com.todo.comment.dto;
+
+public record CommentUpdateDto(
+
+    String content,
+    boolean isDeleted
+) {
+
+}

--- a/src/main/java/com/todo/comment/entity/Comment.java
+++ b/src/main/java/com/todo/comment/entity/Comment.java
@@ -1,0 +1,72 @@
+package com.todo.comment.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.comment.dto.CommentDto;
+import com.todo.comment.dto.CommentUpdateDto;
+import com.todo.todo.entity.Todo;
+import com.todo.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "comments")
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "comment_author_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private User commentAuthor;
+
+  @JoinColumn(name = "todo_id", nullable = false)
+  @ManyToOne(fetch = LAZY)
+  private Todo todo;
+
+  private Long parentCommentId;
+
+  private String content;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  private LocalDateTime deletedAt;
+
+  public static Comment of(User commentAuthor, Todo todo, CommentDto commentDto) {
+
+    return Comment.builder()
+        .commentAuthor(commentAuthor)
+        .todo(todo)
+        .parentCommentId(commentDto.parentCommentId() == null ?
+            null : commentDto.parentCommentId())
+        .content(commentDto.content())
+        .build();
+  }
+
+  public void update(CommentUpdateDto commentUpdateDto) {
+
+    content = commentUpdateDto.content();
+    deletedAt = commentUpdateDto.isDeleted() ? LocalDateTime.now() : null;
+  }
+}

--- a/src/main/java/com/todo/comment/repository/CommentRepository.java
+++ b/src/main/java/com/todo/comment/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.todo.comment.repository;
+
+import com.todo.comment.entity.Comment;
+import com.todo.todo.entity.Todo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+  Page<Comment> findByTodo(Todo todo, Pageable pageable);
+}

--- a/src/main/java/com/todo/comment/service/CommentQueryService.java
+++ b/src/main/java/com/todo/comment/service/CommentQueryService.java
@@ -1,0 +1,22 @@
+package com.todo.comment.service;
+
+import com.todo.comment.entity.Comment;
+import com.todo.comment.repository.CommentRepository;
+import com.todo.todo.entity.Todo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+  private final CommentRepository commentRepository;
+
+  public Page<Comment> findByTodo(Todo todo, Pageable pageable) {
+    return commentRepository.findByTodo(todo, pageable);
+  }
+}

--- a/src/main/java/com/todo/comment/service/CommentService.java
+++ b/src/main/java/com/todo/comment/service/CommentService.java
@@ -1,0 +1,118 @@
+package com.todo.comment.service;
+
+import static com.todo.exception.ErrorCode.COMMENT_NOT_FOUND;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.exception.ErrorCode.PROJECT_NOT_FOUND;
+
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.comment.dto.CommentDto;
+import com.todo.comment.dto.CommentResponseDto;
+import com.todo.comment.dto.CommentUpdateDto;
+import com.todo.comment.entity.Comment;
+import com.todo.comment.repository.CommentRepository;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.service.TodoQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final CommentRepository commentRepository;
+
+  private final CommentQueryService commentQueryService;
+
+  private final UserQueryService userQueryService;
+
+  private final TodoQueryService todoQueryService;
+
+  private final ProjectQueryService projectQueryService;
+
+  private final CollaboratorQueryService collaboratorQueryService;
+
+  @Transactional
+  public void addComment(Authentication auth, Long todoId, CommentDto commentDto) {
+
+    Todo todo = validProject(todoId);
+
+    User commentAuthor = validCommentAuthor(auth, todo);
+
+    commentRepository.save(Comment.of(commentAuthor, todo, commentDto));
+  }
+
+  public Page<CommentResponseDto> getComments(Authentication auth, Long todoId,
+      int page, int pageSize) {
+
+    Todo todo = validProject(todoId);
+
+    validCommentAuthor(auth, todo);
+
+    Pageable pageable = PageRequest.of(page - 1, pageSize);
+
+    Page<Comment> commentPage = commentQueryService.findByTodo(todo, pageable);
+
+    List<CommentResponseDto> dtoList = commentPage.getContent().stream().map(
+        CommentResponseDto::fromEntity).toList();
+
+    return new PageImpl<>(dtoList, pageable, commentPage.getTotalElements());
+  }
+
+  public void updateComments(Authentication auth,
+      Long todoId, Long commentId, CommentUpdateDto commentUpdateDto) {
+
+    Todo todo = validProject(todoId);
+
+    User commentAuthor = validCommentAuthor(auth, todo);
+
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+
+    if (!commentAuthor.getId().equals(comment.getCommentAuthor().getId())) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    comment.update(commentUpdateDto);
+  }
+
+  private Todo validProject(Long todoId) {
+
+    Todo todo = todoQueryService.findById(todoId);
+
+    if (todo.getProjectId() == null) {
+      throw new CustomException(PROJECT_NOT_FOUND);
+    }
+
+    return todo;
+  }
+
+  private User validCommentAuthor(Authentication auth, Todo todo) {
+
+    Project project = projectQueryService.findById(todo.getProjectId());
+
+    User commentAuthor = userQueryService.findByEmail(auth.getName());
+
+    Collaborator collaborator =
+        collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(project, commentAuthor);
+
+    if (collaborator == null ||
+        !commentAuthor.getId().equals(collaborator.getCollaborator().getId())) {
+      throw new CustomException(FORBIDDEN);
+    }
+    return collaborator.getCollaborator();
+  }
+}

--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
   TODO_NOT_FOUND(NOT_FOUND, "할일을 찾을 수 없습니다."),
   PROJECT_NOT_FOUND(NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
   COLLABORATOR_NOT_FOUND(NOT_FOUND, "협업자를 찾을 수 없습니다."),
-
+  COMMENT_NOT_FOUND(NOT_FOUND, "댓글을 찾을 수 없습니다."),
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT

--- a/src/test/java/com/todo/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/todo/comment/service/CommentServiceTest.java
@@ -1,0 +1,183 @@
+package com.todo.comment.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.comment.dto.CommentDto;
+import com.todo.comment.dto.CommentResponseDto;
+import com.todo.comment.dto.CommentUpdateDto;
+import com.todo.comment.entity.Comment;
+import com.todo.comment.repository.CommentRepository;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.service.TodoQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Mock
+  private CommentQueryService commentQueryService;
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private TodoQueryService todoQueryService;
+
+  @Mock
+  private ProjectQueryService projectQueryService;
+
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
+
+  @InjectMocks
+  private CommentService commentService;
+
+  private Authentication auth;
+  private User testUser;
+  private Todo todo;
+  private Project project;
+  private Collaborator collaborator;
+  private Comment comment;
+
+  @BeforeEach
+  void setUp() {
+    auth = new UsernamePasswordAuthenticationToken("test@test.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .name("이름")
+        .profileImageUrl("url")
+        .build();
+
+    todo = Todo.builder()
+        .id(5L)
+        .projectId(10L)
+        .build();
+
+    project = Project.builder()
+        .id(10L)
+        .build();
+
+    collaborator = Collaborator.builder()
+        .id(11L)
+        .collaborator(testUser)
+        .project(project)
+        .build();
+
+    comment = Comment.builder()
+        .id(100L)
+        .parentCommentId(null)
+        .content("댓글요")
+        .commentAuthor(testUser)
+        .build();
+  }
+
+  @Test
+  @DisplayName("댓글 추가에 성공한다")
+  void add_comment_success() {
+    // given
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(
+        project, testUser)).thenReturn(collaborator);
+    // when
+    commentService.addComment(auth, todo.getId(), new CommentDto(null, "댓글요"));
+    // then
+    verify(commentRepository).save(any(Comment.class));
+  }
+
+  @Test
+  @DisplayName("댓글 목록 조회에 성공한다")
+  void get_comments_success() {
+    // given
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(
+        project, testUser)).thenReturn(collaborator);
+
+    Page<Comment> commentPage = new PageImpl<>(Collections.singletonList(comment),
+        PageRequest.of(0, 10), 1);
+    when(commentQueryService.findByTodo(todo, PageRequest.of(0, 10))).thenReturn(commentPage);
+    // when
+    Page<CommentResponseDto> result = commentService.getComments(auth, todo.getId(), 1, 10);
+    // then
+    assertEquals(1, result.getTotalElements());
+    assertEquals("댓글요", result.getContent().get(0).content());
+  }
+
+  @Test
+  @DisplayName("댓글 수정에 성공한다")
+  void update_comment_success() {
+    // given
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(
+        project, testUser)).thenReturn(collaborator);
+    when(commentRepository.findById(comment.getId())).thenReturn(Optional.ofNullable(comment));
+
+    CommentUpdateDto updateDto = new CommentUpdateDto("수정요", false);
+    // when
+    commentService.updateComments(auth, todo.getId(), comment.getId(), updateDto);
+    // then
+    assertEquals("수정요", comment.getContent());
+  }
+
+  @Test
+  @DisplayName("댓글 작성자가 다르면 수정에 실패한다")
+  void update_comment_failure_forbidden() {
+    // given
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(
+        project, testUser)).thenReturn(collaborator);
+
+    User anotherUser = User.builder()
+        .id(300L)
+        .build();
+    Comment anotherComment = Comment.builder()
+        .id(200L)
+        .commentAuthor(anotherUser)
+        .build();
+    when(commentRepository.findById(anotherComment.getId())).thenReturn(
+        Optional.of(anotherComment));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> commentService.updateComments(auth, todo.getId(), anotherComment.getId(),
+            new CommentUpdateDto("수정요", false)));
+    // then
+    assertEquals(FORBIDDEN, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- comment 관련 로직 구현: 댓글 추가, 조회, 수정, 소프트삭제
## 📌 작업 이유 (Why)
- 투두에 댓글 관련 기능 구현
## ✨ 변경 사항 (Changes)
- 댓글 관련 작업시 프로젝트에 참여한 협업자 인지 우선 검증
- 투두에 댓글 추가
- 댓글에 대댓글 기능 구현
- 댓글 조회시 삭제된 댓글은 "삭제된 댓글입니다" 라는 문구 반환
- 댓글 내용은 수정 가능
- 댓글 삭제 가능
## ✅ 테스트 (Tests)
- [ ] 댓글 추가에 성공한다
- [ ] 댓글 목록 조회에 성공한다
- [ ] 댓글 수정에 성공한다
- [ ] 댓글 작성자가 다르면 수정에 실패한다