### PR TITLE
feat: notification 관련 로직 구현 - 각 메서드들간의 알림 생성, 목록 조회, 읽음처리 구현

### DIFF
--- a/src/main/java/com/todo/collaborator/controller/CollaboratorController.java
+++ b/src/main/java/com/todo/collaborator/controller/CollaboratorController.java
@@ -3,6 +3,7 @@ package com.todo.collaborator.controller;
 import com.todo.collaborator.dto.CollaboratorDto;
 import com.todo.collaborator.dto.CollaboratorsDto;
 import com.todo.collaborator.service.CollaboratorService;
+import com.todo.collaborator.type.ConfirmType;
 import com.todo.collaborator.type.RoleType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,17 @@ public class CollaboratorController {
 
     return ResponseEntity.ok(
         collaboratorService.updateCollaborator(auth, projectId, collaboratorId, roleType));
+  }
+
+  @PutMapping("/{projectId}/collaborators/{collaboratorId}/confirm")
+  public ResponseEntity<Void> updateCornFirm(Authentication auth,
+      @PathVariable("projectId") Long projectId,
+      @PathVariable("collaboratorId") Long collaboratorId,
+      @RequestBody ConfirmType confirmType) {
+
+    collaboratorService.updateConfirm(auth, projectId, collaboratorId, confirmType);
+
+    return ResponseEntity.ok().build();
   }
 
   @DeleteMapping("/{projectId}/collaborators/{collaboratorId}")

--- a/src/main/java/com/todo/collaborator/entity/Collaborator.java
+++ b/src/main/java/com/todo/collaborator/entity/Collaborator.java
@@ -61,4 +61,9 @@ public class Collaborator {
 
     this.roleType = roleType;
   }
+
+  public void updateConfirm(ConfirmType confirmType) {
+
+    this.confirmType = confirmType;
+  }
 }

--- a/src/main/java/com/todo/collaborator/service/CollaboratorService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorService.java
@@ -10,8 +10,10 @@ import com.todo.collaborator.dto.CollaboratorDto;
 import com.todo.collaborator.dto.CollaboratorsDto;
 import com.todo.collaborator.entity.Collaborator;
 import com.todo.collaborator.repository.CollaboratorRepository;
+import com.todo.collaborator.type.ConfirmType;
 import com.todo.collaborator.type.RoleType;
 import com.todo.exception.CustomException;
+import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
 import com.todo.user.entity.User;
@@ -36,13 +38,15 @@ public class CollaboratorService {
 
   private final CollaboratorRepository collaboratorRepository;
 
+  private final NotificationService notificationService;
+
   @Transactional
   public void addCollaborator(Authentication auth, Long projectId,
       CollaboratorDto collaboratorDto) {
 
     Project project = findOwnerWithProject(auth, projectId);
 
-    registerOwner(project.getOwner(), project);
+    User owner = registerOwner(project.getOwner(), project);
 
     User invitedUser = userQueryService.findById(collaboratorDto.collaboratorId());
 
@@ -53,9 +57,11 @@ public class CollaboratorService {
 
     collaboratorRepository.save(
         Collaborator.of(invitedUser, project, collaboratorDto.roleType(), FALSE));
+
+    notificationService.sendInvitationNotification(owner, invitedUser, project);
   }
 
-  private void registerOwner(User owner, Project project) {
+  private User registerOwner(User owner, Project project) {
 
     boolean ownerAlreadyExists = collaboratorQueryService.existsByProjectAndCollaboratorAndIsConfirmed(
         project, owner);
@@ -63,6 +69,7 @@ public class CollaboratorService {
     if (!ownerAlreadyExists) {
       collaboratorRepository.save(Collaborator.of(owner, project, EDITOR, TRUE));
     }
+    return owner;
   }
 
   public List<CollaboratorsDto> getCollaborators(Authentication auth, Long projectId) {
@@ -104,7 +111,13 @@ public class CollaboratorService {
 
     collaboratorRepository.delete(collaboratorQueryService.findById(collaboratorId));
 
+    User deletedUser = userQueryService.findById(collaboratorId);
+
     List<Collaborator> collaborators = collaboratorQueryService.findByProject(project);
+
+    List<User> users = collaborators.stream().map(Collaborator::getCollaborator).toList();
+
+    notificationService.notifyProjectUserRemoval(users, deletedUser, project);
 
     return collaborators.stream().map(CollaboratorsDto::fromEntity).collect(Collectors.toList());
   }
@@ -119,5 +132,27 @@ public class CollaboratorService {
       throw new CustomException(FORBIDDEN);
     }
     return project;
+  }
+
+  public void updateConfirm(Authentication auth, Long projectId, Long collaboratorId,
+      ConfirmType confirmType) {
+
+    User invitedUser = userQueryService.findByEmail(auth.getName());
+
+    Project project = projectQueryService.findById(projectId);
+
+    Collaborator collaborator = collaboratorQueryService.findById(collaboratorId);
+
+    if (!invitedUser.getId().equals(collaborator.getCollaborator().getId())) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    collaborator.updateConfirm(confirmType);
+
+    List<Collaborator> collaborators = collaboratorQueryService.findByProject(project);
+
+    List<User> users = collaborators.stream().map(Collaborator::getCollaborator).toList();
+
+    notificationService.notifyUserOnJoin(users, invitedUser, project);
   }
 }

--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -26,12 +26,15 @@ public enum ErrorCode {
   PROJECT_NOT_FOUND(NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
   COLLABORATOR_NOT_FOUND(NOT_FOUND, "협업자를 찾을 수 없습니다."),
   COMMENT_NOT_FOUND(NOT_FOUND, "댓글을 찾을 수 없습니다."),
+  NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림을 찾을 수 없습니다."),
+
   // 408 REQUEST TIMEOUT
 
   // 409 CONFLICT
   ALREADY_EXISTS_EMAIL(CONFLICT, "이미 존재하는 메일입니다."),
   VERSION_CONFLICT(CONFLICT, "동시성 충돌이 발생했습니다. 다시 시도해 주세요."),
   ALREADY_EXISTS_USER(CONFLICT, "이미 초대된 회원입니다."),
+  ALREADY_EXISTS_READ(CONFLICT, "이미 읽은 알림입니다."),
 
   // 500 INTERNAL SEVER ERROR
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/todo/notification/controller/NotificationController.java
+++ b/src/main/java/com/todo/notification/controller/NotificationController.java
@@ -1,0 +1,41 @@
+package com.todo.notification.controller;
+
+import com.todo.notification.dto.NotificationDto;
+import com.todo.notification.service.NotificationService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  @GetMapping
+  public ResponseEntity<Page<NotificationDto>> getNotifications(Authentication auth,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    return ResponseEntity.ok(notificationService.getNotifications(auth, page, pageSize));
+  }
+
+  @PutMapping("/{notificationId}")
+  public ResponseEntity<Page<NotificationDto>> updateNotification(Authentication auth,
+      @PathVariable Long notificationId,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    return ResponseEntity.ok(
+        notificationService.updateNotifications(auth, notificationId, page, pageSize));
+  }
+}

--- a/src/main/java/com/todo/notification/dto/NotificationDto.java
+++ b/src/main/java/com/todo/notification/dto/NotificationDto.java
@@ -1,0 +1,15 @@
+package com.todo.notification.dto;
+
+import com.todo.notification.entity.Notification;
+
+public record NotificationDto(
+
+    Long notificationId,
+    String message
+) {
+
+  public static NotificationDto fromEntity(Notification notification) {
+
+    return new NotificationDto(notification.getId(), notification.getMessage());
+  }
+}

--- a/src/main/java/com/todo/notification/entity/Notification.java
+++ b/src/main/java/com/todo/notification/entity/Notification.java
@@ -1,0 +1,59 @@
+package com.todo.notification.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "notifications")
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @JoinColumn(name = "user_id", nullable = false)
+  @ManyToOne
+  private User user;
+
+  private String message;
+
+  private boolean isRead;
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+  public static Notification of(User user, String message) {
+
+    return Notification.builder()
+        .user(user)
+        .message(message)
+        .isRead(false)
+        .build();
+  }
+
+  public void update() {
+
+    isRead = true;
+  }
+}

--- a/src/main/java/com/todo/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/todo/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.todo.notification.repository;
+
+import com.todo.notification.entity.Notification;
+import com.todo.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  Page<Notification> findByUserAndReadFalse(User user, Pageable pageable);
+}

--- a/src/main/java/com/todo/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/todo/notification/service/NotificationQueryService.java
@@ -1,0 +1,23 @@
+package com.todo.notification.service;
+
+import com.todo.notification.entity.Notification;
+import com.todo.notification.repository.NotificationRepository;
+import com.todo.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotificationQueryService {
+
+  private final NotificationRepository notificationRepository;
+
+  public Page<Notification> findByUserIsReadFalse(User user, Pageable pageable) {
+
+    return notificationRepository.findByUserAndReadFalse(user, pageable);
+  }
+}

--- a/src/main/java/com/todo/notification/service/NotificationService.java
+++ b/src/main/java/com/todo/notification/service/NotificationService.java
@@ -1,0 +1,138 @@
+package com.todo.notification.service;
+
+import static com.todo.exception.ErrorCode.ALREADY_EXISTS_READ;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.exception.ErrorCode.NOTIFICATION_NOT_FOUND;
+
+import com.todo.exception.CustomException;
+import com.todo.notification.dto.NotificationDto;
+import com.todo.notification.entity.Notification;
+import com.todo.notification.repository.NotificationRepository;
+import com.todo.project.entity.Project;
+import com.todo.todo.entity.Todo;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  private final UserQueryService userQueryService;
+
+  private final NotificationQueryService notificationQueryService;
+
+  @Transactional
+  public void saveNotification(User user, String message) {
+
+    notificationRepository.save(Notification.of(user, message));
+  }
+
+  public void saveNotificationMultiple(List<User> users, String message) {
+
+    for (User user : users) {
+      saveNotification(user, message);
+    }
+  }
+
+  public void sendInvitationNotification(User owner, User invitedUser, Project project) {
+
+    String message = String.format("%s 님이 %s 프로젝트에 초대하셨습니다. 참여하시겠습니까?",
+        owner.getName(), project.getName());
+
+    saveNotification(invitedUser, message);
+  }
+
+  public void notifyUserOnJoin(List<User> users, User invitedUser, Project project) {
+
+    String message = String.format("%s 님이 %s 프로젝트에 참여하였습니다.",
+        invitedUser.getName(), project.getName());
+
+    saveNotificationMultiple(users, message);
+  }
+
+  public void notifyProjectUserRemoval(List<User> users, User deletedUser, Project project) {
+
+    String message = String.format("%s 님이 %s 프로젝트에서 제외되었습니다.",
+        deletedUser.getName(), project.getName());
+
+    saveNotificationMultiple(users, message);
+  }
+
+  public void notifyTodoAddedByOthers(List<User> users, Todo todo, Project project) {
+
+    String message = String.format("%s 프로젝트에 %s Todo 가 생성되었습니다.",
+        project.getName(), todo.getTitle());
+
+    saveNotificationMultiple(users, message);
+  }
+
+  public void notifyTodoStatusChangedByOthers(List<User> users, Todo todo, Project project) {
+
+    String message = String.format("%s 프로젝트의 %s Todo 의 상태가 변경되었습니다.",
+        project.getName(), todo.getTitle());
+
+    saveNotificationMultiple(users, message);
+  }
+
+  public void notifyCommentAddedByOthers(List<User> users, Todo todo, Project project) {
+
+    String message = String.format("%s 프로젝트의 %s Todo 에 댓글이 추가되었습니다.",
+        project.getName(), todo.getTitle());
+
+    saveNotificationMultiple(users, message);
+  }
+
+  public Page<NotificationDto> getNotifications(Authentication auth, int page, int pageSize) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    return paginateResult(page, pageSize, user);
+  }
+
+  @Transactional
+  public Page<NotificationDto> updateNotifications(Authentication auth, Long notificationId,
+      int page, int pageSize) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND));
+
+    if (!notification.getUser().getId().equals(user.getId())) {
+
+      throw new CustomException(FORBIDDEN);
+    }
+
+    if (notification.isRead()) {
+
+      throw new CustomException(ALREADY_EXISTS_READ);
+    }
+
+    notification.update();
+
+    return paginateResult(page, pageSize, user);
+  }
+
+  private Page<NotificationDto> paginateResult(int page, int pageSize, User user) {
+    Pageable pageable = PageRequest.of(page - 1, pageSize);
+
+    Page<Notification> notifications = notificationQueryService.findByUserIsReadFalse(user, pageable);
+
+    List<NotificationDto> dtoList = notifications.getContent().stream().map(
+        NotificationDto::fromEntity).toList();
+
+    return new PageImpl<>(dtoList, pageable, notifications.getTotalElements());
+  }
+}

--- a/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
+++ b/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
@@ -13,6 +13,7 @@ import com.todo.collaborator.dto.CollaboratorDto;
 import com.todo.collaborator.dto.CollaboratorsDto;
 import com.todo.collaborator.entity.Collaborator;
 import com.todo.collaborator.repository.CollaboratorRepository;
+import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
 import com.todo.user.entity.User;
@@ -42,6 +43,9 @@ class CollaboratorServiceTest {
 
   @Mock
   private CollaboratorRepository collaboratorRepository;
+
+  @Mock
+  private NotificationService notificationService;
 
   @InjectMocks
   private CollaboratorService collaboratorService;

--- a/src/test/java/com/todo/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/todo/comment/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import com.todo.comment.dto.CommentUpdateDto;
 import com.todo.comment.entity.Comment;
 import com.todo.comment.repository.CommentRepository;
 import com.todo.exception.CustomException;
+import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
 import com.todo.todo.entity.Todo;
@@ -56,6 +57,9 @@ class CommentServiceTest {
 
   @Mock
   private CollaboratorQueryService collaboratorQueryService;
+
+  @Mock
+  private NotificationService notificationService;
 
   @InjectMocks
   private CommentService commentService;

--- a/src/test/java/com/todo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/todo/notification/service/NotificationServiceTest.java
@@ -1,0 +1,177 @@
+package com.todo.notification.service;
+
+import static com.todo.exception.ErrorCode.ALREADY_EXISTS_READ;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.exception.CustomException;
+import com.todo.notification.dto.NotificationDto;
+import com.todo.notification.entity.Notification;
+import com.todo.notification.repository.NotificationRepository;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+  @Mock
+  private UserQueryService userQueryService;
+  @Mock
+  private NotificationQueryService notificationQueryService;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  private Authentication auth;
+  private User testUser;
+  private Notification notification;
+
+  @BeforeEach
+  void setUp() {
+
+    auth = new UsernamePasswordAuthenticationToken("test@test.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .build();
+
+    notification = Notification.builder()
+        .id(10L)
+        .user(testUser)
+        .isRead(false)
+        .message("테스트용")
+        .build();
+  }
+
+  @Test
+  @DisplayName("알림 저장이 성공한다")
+  void save_notification_success() {
+    // given
+    // when
+    notificationService.saveNotification(testUser, "테스트");
+    // then
+    verify(notificationRepository).save(any(Notification.class));
+  }
+
+  @Test
+  @DisplayName("여러명의 알림 저장이 성공한다")
+  void save_notification_multiple_success() {
+    // given
+    User testUser2 = User.builder()
+        .id(2L)
+        .build();
+    List<User> users = List.of(testUser, testUser2);
+    // when
+    notificationService.saveNotificationMultiple(users, "테스트");
+    // then
+    verify(notificationRepository, times(users.size())).save(any(Notification.class));
+  }
+
+  @Test
+  @DisplayName("알림 목록 조회가 성공한다")
+  void get_notifications_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+
+    List<Notification> notifications = Collections.singletonList(
+        Notification.of(testUser, "테스트 메세지"));
+
+    Page<Notification> dtoPage = new PageImpl<>(notifications, PageRequest.of(0, 10),
+        notifications.size());
+
+    when(notificationQueryService.findByUserIsReadFalse(testUser, PageRequest.of(0, 10)))
+        .thenReturn(dtoPage);
+    // when
+    Page<NotificationDto> result = notificationService.getNotifications(auth, 1, 10);
+    // then
+    assertEquals(1, result.getTotalElements());
+    assertEquals("테스트 메세지", result.getContent().get(0).message());
+  }
+
+  @Test
+  @DisplayName("알림 읽음처리에 성공한다")
+  void update_notification_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(notificationRepository.findById(notification.getId()))
+        .thenReturn(Optional.of(notification));
+
+    List<Notification> notifications = Collections.singletonList(notification);
+    Page<Notification> dtoPage = new PageImpl<>(notifications, PageRequest.of(0, 10),
+        notifications.size());
+    when(notificationQueryService.findByUserIsReadFalse(testUser, PageRequest.of(0, 10)))
+        .thenReturn(dtoPage);
+    // when
+    notificationService.updateNotifications(auth, notification.getId(), 1, 10);
+    // then
+    assertTrue(notification.isRead());
+  }
+
+  @Test
+  @DisplayName("알림 소유자가 아니면 읽음처리에 실패한다")
+  void update_notification_failure_forbidden() {
+    // given
+    User testUser2 = User.builder()
+        .id(2L)
+        .email("test2@test.com")
+        .build();
+
+    Notification notification2 = Notification.builder()
+        .id(20L)
+        .user(testUser2)
+        .build();
+
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(notificationRepository.findById(notification2.getId()))
+        .thenReturn(Optional.of(notification2));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotifications(auth, notification2.getId(), 1, 10));
+    // then
+    assertEquals(e.getErrorCode(), FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("이미 읽은 알림인 경우 읽음처리에 실패한다")
+  void update_notification_failure_conflict() {
+    // given
+    Notification notification2 = Notification.builder()
+        .id(20L)
+        .user(testUser)
+        .isRead(true)
+        .build();
+
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(notificationRepository.findById(notification2.getId()))
+        .thenReturn(Optional.of(notification2));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotifications(auth, notification2.getId(), 1, 10));
+    // then
+    assertEquals(e.getErrorCode(), ALREADY_EXISTS_READ);
+  }
+}

--- a/src/test/java/com/todo/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/todo/todo/service/TodoServiceTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.pagehelper.PageInfo;
+import com.todo.collaborator.service.CollaboratorQueryService;
 import com.todo.exception.CustomException;
+import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
 import com.todo.todo.dto.TodoDto;
@@ -58,6 +60,12 @@ class TodoServiceTest {
 
   @Mock
   private EntityManager entityManager;
+
+  @Mock
+  private NotificationService notificationService;
+
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
 
   @InjectMocks
   private TodoService todoService;


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- notification 관련 로직 구현: 각 메서드들간의 알림 생성, 목록 조회, 읽음처리 구현
## 📌 작업 이유 (Why)
- 알림 정보 관련 구현
## ✨ 변경 사항 (Changes)
- 프로젝트 내의 각 활동에 대해 적절한 사용자들에게 알림 전송
- 누군가가 나를 프로젝트에 초대하였을 때 알림 전송
- 해당 프로젝트에 참여하였을 때 팀원들에게 알림 전송
- 해당 프로젝트에 누군가가 제외되었을 때 팀원들에게 알림 전송
- 해당 프로젝트에 할일이 생성되었을 때 팀원들에게 알림 전송
- 해당 프로젝트의 할일의 상태가 변경되었을 때 팀원들에게 알림 전송
- 해당 프로젝트의 할일에 댓글이 달리면 팀원들에게 알림 전송
- 알림 목록을 조회하여 읽지않은 알림 조회
- 알림 읽음처리 가능
## ✅ 테스트 (Tests)
- [ ] 알림 저장이 성공한다
- [ ] 여러명의 알림 저장이 성공한다
- [ ] 알림 목록 조회가 성공한다
- [ ] 알림 읽음처리에 성공한다
- [ ] 알림 소유자가 아니면 읽음처리에 실패한다
- [ ] 이미 읽은 알림인 경우 읽음처리에 실패한다