### PR TITLE
feat: activityLog 관련 로직 구현 - 각 메서드들간의 로그 생성, 로그 조회 구현

### DIFF
--- a/src/main/java/com/todo/activity/controller/ActivityLogController.java
+++ b/src/main/java/com/todo/activity/controller/ActivityLogController.java
@@ -1,0 +1,33 @@
+package com.todo.activity.controller;
+
+import com.todo.activity.dto.ActivityLogResponseDto;
+import com.todo.activity.service.ActivityLogService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/project")
+public class ActivityLogController {
+
+  private final ActivityLogService activityLogService;
+
+  @GetMapping("/{project_id}/logs")
+  public ResponseEntity<Page<ActivityLogResponseDto>> getActivityLogs(Authentication auth,
+      @PathVariable("project_id") Long projectId,
+      @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
+      @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
+
+    Page<ActivityLogResponseDto> dto = activityLogService.getActivityLogs(auth, projectId, page, pageSize);
+
+    return ResponseEntity.ok(dto);
+  }
+}

--- a/src/main/java/com/todo/activity/dto/ActivityLogResponseDto.java
+++ b/src/main/java/com/todo/activity/dto/ActivityLogResponseDto.java
@@ -1,0 +1,34 @@
+package com.todo.activity.dto;
+
+import com.todo.activity.entity.ActivityLog;
+import com.todo.activity.type.ActionType;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ActivityLogResponseDto(
+
+    Long activityLogId,
+    String actionDetail,
+    String changerName,
+    ActionType actionType,
+    Long todoId,
+    String todoTitle,
+    LocalDateTime createdAt
+) {
+
+  public static ActivityLogResponseDto fromEntity(ActivityLog activityLog) {
+
+    Long todoId = activityLog.getTodo() != null ? activityLog.getTodo().getId() : null;
+    String todoTitle = activityLog.getTodo() != null ? activityLog.getTodo().getTitle() : null;
+
+    return ActivityLogResponseDto.builder()
+        .activityLogId(activityLog.getId())
+        .actionDetail(activityLog.getActionDetail())
+        .changerName(activityLog.getChangerName())
+        .todoId(todoId)
+        .todoTitle(todoTitle)
+        .createdAt(activityLog.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/activity/entity/ActivityLog.java
+++ b/src/main/java/com/todo/activity/entity/ActivityLog.java
@@ -1,12 +1,16 @@
-package com.todo.notification.entity;
+package com.todo.activity.entity;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
-import com.todo.user.entity.User;
+import com.todo.activity.type.ActionType;
+import com.todo.project.entity.Project;
+import com.todo.todo.entity.Todo;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -25,36 +29,41 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Builder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
-@Table(name = "notifications")
+@Table(name = "activity_logs")
 @EntityListeners(AuditingEntityListener.class)
-public class Notification {
+public class ActivityLog {
 
   @Id
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
 
-  @JoinColumn(name = "user_id", nullable = false)
   @ManyToOne(fetch = LAZY)
-  private User user;
+  @JoinColumn(name = "project_id", nullable = false)
+  private Project project;
 
-  private String message;
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "todo_id")
+  private Todo todo;
 
-  private boolean isRead;
+  @Enumerated(STRING)
+  private ActionType actionType;
+
+  private String actionDetail;
+
+  private String changerName;
 
   @CreatedDate
   private LocalDateTime createdAt;
 
-  public static Notification of(User user, String message) {
+  public static ActivityLog of(Project project, Todo todo, ActionType actionType,
+      String actionDetail, String changerName) {
 
-    return Notification.builder()
-        .user(user)
-        .message(message)
-        .isRead(false)
+    return ActivityLog.builder()
+        .project(project)
+        .todo(todo)
+        .actionType(actionType)
+        .actionDetail(actionDetail)
+        .changerName(changerName)
         .build();
-  }
-
-  public void update() {
-
-    isRead = true;
   }
 }

--- a/src/main/java/com/todo/activity/repository/ActivityLogRepository.java
+++ b/src/main/java/com/todo/activity/repository/ActivityLogRepository.java
@@ -1,0 +1,12 @@
+package com.todo.activity.repository;
+
+import com.todo.activity.entity.ActivityLog;
+import com.todo.project.entity.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
+
+  Page<ActivityLog> findByProject(Project project, Pageable pageable);
+}

--- a/src/main/java/com/todo/activity/service/ActivityLogService.java
+++ b/src/main/java/com/todo/activity/service/ActivityLogService.java
@@ -1,0 +1,109 @@
+package com.todo.activity.service;
+
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+
+import com.todo.activity.dto.ActivityLogResponseDto;
+import com.todo.activity.entity.ActivityLog;
+import com.todo.activity.repository.ActivityLogRepository;
+import com.todo.activity.type.ActionType;
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.todo.entity.Todo;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ActivityLogService {
+
+  private final ActivityLogRepository activityLogRepository;
+
+  private final UserQueryService userQueryService;
+
+  private final ProjectQueryService projectQueryService;
+
+  private final CollaboratorQueryService collaboratorQueryService;
+
+  private final ActivityQueryService activityQueryService;
+
+  public Page<ActivityLogResponseDto> getActivityLogs(
+      Authentication auth, Long projectId, int page, int pageSize) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    Project project = projectQueryService.findById(projectId);
+
+    Collaborator collaborator = collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(
+        project, user);
+
+    if (collaborator == null) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    Pageable pageable = PageRequest.of(page - 1, pageSize);
+
+    Page<ActivityLog> activityLogs = activityQueryService.findByProject(project,
+        pageable);
+
+    List<ActivityLogResponseDto> dtoList = activityLogs.getContent().stream()
+        .map(ActivityLogResponseDto::fromEntity).toList();
+
+    return new PageImpl<>(dtoList, pageable, activityLogs.getTotalElements());
+  }
+
+  @Transactional
+  public void saveLog(Project project, Todo todo, ActionType actionType, String changerName, String actionDetail) {
+
+    ActivityLog activityLog = ActivityLog.of(project, todo, actionType, actionDetail, changerName);
+
+    activityLogRepository.save(activityLog);
+  }
+
+  public void recordTodoCreation(Project project, Todo todo, ActionType actionType, String changerName) {
+
+    String actionDetail = String.format("%s 할일이 생성되었습니다.", todo.getTitle());
+
+    saveLog(project, todo, actionType, changerName, actionDetail);
+  }
+
+  public void recordTodoUpdate(Project project, Todo todo, ActionType actionType, String changerName) {
+
+    String actionDetail = String.format("%s 할일이 수정 되었습니다.", todo.getTitle());
+
+    saveLog(project, todo, actionType, changerName, actionDetail);
+  }
+
+  public void recordTodoComplete(Project project, Todo todo, ActionType actionType, String changerName) {
+
+    String actionDetail = String.format("%s 할일이 완료 되었습니다.", todo.getTitle());
+
+    saveLog(project, todo, actionType, changerName, actionDetail);
+  }
+
+  public void recordProjectParticipation(Project project, ActionType actionType, String invitedUser) {
+
+    String actionDetail = String.format("%s 님이 %s 프로젝트에 참여하였습니다.", invitedUser, project.getName());
+
+    saveLog(project, null, actionType, invitedUser, actionDetail);
+  }
+
+  public void recordProjectExclusion(Project project, ActionType actionType, String deletedUser) {
+
+    String actionDetail = String.format("%s 님이 %s 프로젝트에 제외되었습니다.", deletedUser, project.getName());
+
+    saveLog(project, null, actionType, deletedUser, actionDetail);
+  }
+}

--- a/src/main/java/com/todo/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/todo/activity/service/ActivityQueryService.java
@@ -1,0 +1,23 @@
+package com.todo.activity.service;
+
+import com.todo.activity.entity.ActivityLog;
+import com.todo.activity.repository.ActivityLogRepository;
+import com.todo.project.entity.Project;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ActivityQueryService {
+
+  private final ActivityLogRepository activityLogRepository;
+
+  public Page<ActivityLog> findByProject(Project project, Pageable pageable) {
+
+    return activityLogRepository.findByProject(project, pageable);
+  }
+}

--- a/src/main/java/com/todo/activity/type/ActionType.java
+++ b/src/main/java/com/todo/activity/type/ActionType.java
@@ -1,0 +1,5 @@
+package com.todo.activity.type;
+
+public enum ActionType {
+  TODO, PROJECT
+}

--- a/src/test/java/com/todo/activity/service/ActivityLogServiceTest.java
+++ b/src/test/java/com/todo/activity/service/ActivityLogServiceTest.java
@@ -1,0 +1,141 @@
+package com.todo.activity.service;
+
+import static com.todo.activity.type.ActionType.PROJECT;
+import static com.todo.activity.type.ActionType.TODO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.activity.dto.ActivityLogResponseDto;
+import com.todo.activity.entity.ActivityLog;
+import com.todo.activity.repository.ActivityLogRepository;
+import com.todo.collaborator.entity.Collaborator;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.todo.entity.Todo;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityLogServiceTest {
+
+  @Mock
+  private ActivityLogRepository activityLogRepository;
+
+  @Mock
+  private UserQueryService userQueryService;
+
+  @Mock
+  private ProjectQueryService projectQueryService;
+
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
+
+  @Mock
+  private ActivityQueryService activityQueryService;
+
+  @InjectMocks
+  private ActivityLogService activityLogService;
+
+  private Authentication auth;
+  private User testUser;
+  private Project project;
+  private Todo todo;
+  private Collaborator collaborator;
+
+  @BeforeEach
+  void setUp() {
+
+    auth = new UsernamePasswordAuthenticationToken("test@test.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .build();
+
+    project = Project.builder()
+        .id(10L)
+        .name("프로젝트")
+        .build();
+
+    todo = Todo.builder()
+        .id(20L)
+        .title("투두")
+        .build();
+
+    collaborator = Collaborator.builder()
+        .id(30L)
+        .collaborator(testUser)
+        .build();
+  }
+
+  @Test
+  @DisplayName("활동 로그 조회에 성공한다")
+  void get_activity_log_success() {
+    // given
+    when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(collaboratorQueryService.findByProjectAndCollaboratorIsConfirmed(project, testUser)).thenReturn(collaborator);
+
+    ActivityLog activityLog = ActivityLog.builder()
+        .id(100L)
+        .project(project)
+        .build();
+
+    ActivityLog activityLog2 = ActivityLog.builder()
+        .id(200L)
+        .project(project)
+        .build();
+
+    ActivityLog activityLog3 = ActivityLog.builder()
+        .id(300L)
+        .project(project)
+        .build();
+
+    List<ActivityLog> logs = List.of(activityLog, activityLog2, activityLog3);
+
+    Page<ActivityLog> logPage = new PageImpl<>(logs, PageRequest.of(0, 10), logs.size());
+    when(activityQueryService.findByProject(project, PageRequest.of(0, 10))).thenReturn(logPage);
+    // when
+    Page<ActivityLogResponseDto> result = activityLogService.getActivityLogs(auth, project.getId(), 1, 10);
+    // then
+    assertEquals(3, result.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("투두 활동 로그 저장에 성공한다")
+  void save_todo_activity_log_success() {
+    // given
+    String actionDetail = String.format("%s 할일이 생성되었습니다.", todo.getTitle());
+    // when
+    activityLogService.recordTodoCreation(project, todo, TODO, actionDetail);
+    // then
+    verify(activityLogRepository).save(any(ActivityLog.class));
+  }
+
+  @Test
+  @DisplayName("프로젝트 참여 활동 로그 저장에 성공한다")
+  void save_project_join_activity_log_success() {
+    // given
+    String actionDetail = String.format("%s 님이 %s 프로젝트에 참여하였습니다.", testUser.getName(), project.getName());
+    // when
+    activityLogService.recordProjectParticipation(project, PROJECT, actionDetail);
+    // then
+    verify(activityLogRepository).save(any(ActivityLog.class));
+  }
+}

--- a/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
+++ b/src/test/java/com/todo/collaborator/service/CollaboratorServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.todo.activity.service.ActivityLogService;
 import com.todo.collaborator.dto.CollaboratorDto;
 import com.todo.collaborator.dto.CollaboratorsDto;
 import com.todo.collaborator.entity.Collaborator;
@@ -46,6 +47,9 @@ class CollaboratorServiceTest {
 
   @Mock
   private NotificationService notificationService;
+
+  @Mock
+  private ActivityLogService activityLogService;
 
   @InjectMocks
   private CollaboratorService collaboratorService;

--- a/src/test/java/com/todo/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/todo/todo/service/TodoServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.pagehelper.PageInfo;
+import com.todo.activity.service.ActivityLogService;
 import com.todo.collaborator.service.CollaboratorQueryService;
 import com.todo.exception.CustomException;
 import com.todo.notification.service.NotificationService;
@@ -66,6 +67,9 @@ class TodoServiceTest {
 
   @Mock
   private CollaboratorQueryService collaboratorQueryService;
+
+  @Mock
+  private ActivityLogService activityLogService;
 
   @InjectMocks
   private TodoService todoService;


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- feat: activityLog 관련 로직 구현: 각 메서드들간의 로그 생성, 로그 조회 구현
## 📌 작업 이유 (Why)
- 프로젝트 내의 활동 기록에 대한 로직 구현
## ✨ 변경 사항 (Changes)
- 각 메서드들의 행위에 대한 활동 기록
- 협업 프로젝트의 할일이 생성되면 활동 로그 기록
- 협업 프로젝트의 할일이 수정되면 활동 로그 기록
- 협업 프로젝트의 할일이 완료되면 활동 로그 기록
- 협업 프로젝트에 팀원이 추가되면 활동 로그 기록
- 협업 프로젝트에 팀원이 제외되면 활동 로그 기록
- 해당 프로젝트의 활동 기록 조회 가능
## ✅ 테스트 (Tests)
- [ ] 활동 로그 조회에 성공한다
- [ ] 투두 활동 로그 저장에 성공한다
- [ ] 프로젝트 참여 활동 로그 저장에 성공한다