### PR TITLE
feat: snapshot 관련 로직 구현 - 할일 버전 업데이트 시 스냅샷 저장 로직, 할일의 특정 버전으로 롤백 기능 구현

### DIFF
--- a/src/main/java/com/todo/activity/dto/ActivityLogResponseDto.java
+++ b/src/main/java/com/todo/activity/dto/ActivityLogResponseDto.java
@@ -14,6 +14,8 @@ public record ActivityLogResponseDto(
     ActionType actionType,
     Long todoId,
     String todoTitle,
+    Long todoVersion,
+    Long snapshotId,
     LocalDateTime createdAt
 ) {
 
@@ -28,6 +30,8 @@ public record ActivityLogResponseDto(
         .changerName(activityLog.getChangerName())
         .todoId(todoId)
         .todoTitle(todoTitle)
+        .todoVersion(activityLog.getTodoVersion())
+        .snapshotId(activityLog.getSnapshotId())
         .createdAt(activityLog.getCreatedAt())
         .build();
   }

--- a/src/main/java/com/todo/activity/entity/ActivityLog.java
+++ b/src/main/java/com/todo/activity/entity/ActivityLog.java
@@ -52,11 +52,15 @@ public class ActivityLog {
 
   private String changerName;
 
+  private Long todoVersion;
+
+  private Long snapshotId;
+
   @CreatedDate
   private LocalDateTime createdAt;
 
   public static ActivityLog of(Project project, Todo todo, ActionType actionType,
-      String actionDetail, String changerName) {
+      String actionDetail, String changerName, Long todoVersion, Long snapshotId) {
 
     return ActivityLog.builder()
         .project(project)
@@ -64,6 +68,8 @@ public class ActivityLog {
         .actionType(actionType)
         .actionDetail(actionDetail)
         .changerName(changerName)
+        .todoVersion(todoVersion)
+        .snapshotId(snapshotId)
         .build();
   }
 }

--- a/src/main/java/com/todo/activity/service/ActivityLogService.java
+++ b/src/main/java/com/todo/activity/service/ActivityLogService.java
@@ -65,45 +65,59 @@ public class ActivityLogService {
   }
 
   @Transactional
-  public void saveLog(Project project, Todo todo, ActionType actionType, String changerName, String actionDetail) {
+  public void saveLog(Project project, Todo todo, ActionType actionType, String changerName,
+      String actionDetail, Long todoVersion, Long snapshotId) {
 
-    ActivityLog activityLog = ActivityLog.of(project, todo, actionType, actionDetail, changerName);
+    ActivityLog activityLog = ActivityLog.of(project, todo, actionType, actionDetail, changerName, todoVersion, snapshotId);
 
     activityLogRepository.save(activityLog);
   }
 
-  public void recordTodoCreation(Project project, Todo todo, ActionType actionType, String changerName) {
+  public void recordTodoCreation(Project project, Todo todo, ActionType actionType,
+      String changerName, Long todoVersion, Long snapshotId) {
 
     String actionDetail = String.format("%s 할일이 생성되었습니다.", todo.getTitle());
 
-    saveLog(project, todo, actionType, changerName, actionDetail);
+    saveLog(project, todo, actionType, changerName, actionDetail, todoVersion, snapshotId);
   }
 
-  public void recordTodoUpdate(Project project, Todo todo, ActionType actionType, String changerName) {
+  public void recordTodoUpdate(Project project, Todo todo, ActionType actionType,
+      String changerName, Long todoVersion, Long snapshotId) {
 
     String actionDetail = String.format("%s 할일이 수정 되었습니다.", todo.getTitle());
 
-    saveLog(project, todo, actionType, changerName, actionDetail);
+    saveLog(project, todo, actionType, changerName, actionDetail, todoVersion, snapshotId);
   }
 
-  public void recordTodoComplete(Project project, Todo todo, ActionType actionType, String changerName) {
+  public void recordTodoComplete(Project project, Todo todo, ActionType actionType,
+      String changerName, Long todoVersion, Long snapshotId) {
 
     String actionDetail = String.format("%s 할일이 완료 되었습니다.", todo.getTitle());
 
-    saveLog(project, todo, actionType, changerName, actionDetail);
+    saveLog(project, todo, actionType, changerName, actionDetail, todoVersion, snapshotId);
   }
 
-  public void recordProjectParticipation(Project project, ActionType actionType, String invitedUser) {
+  public void recordTodoRollback(Project project, Todo todo, ActionType actionType,
+      String changerName, Long previousVersion, Long currentVersion, Long snapshotId) {
+
+    String actionDetail = String.format("%s 님이 %s 할일을 롤백하였습니다. (롤백 전 버전: %d)",
+        changerName, todo.getTitle(), previousVersion);
+
+    saveLog(project, todo, actionType, changerName, actionDetail, currentVersion, snapshotId);
+  }
+
+  public void recordProjectParticipation(Project project, ActionType actionType,
+      String invitedUser) {
 
     String actionDetail = String.format("%s 님이 %s 프로젝트에 참여하였습니다.", invitedUser, project.getName());
 
-    saveLog(project, null, actionType, invitedUser, actionDetail);
+    saveLog(project, null, actionType, invitedUser, actionDetail, null, null);
   }
 
   public void recordProjectExclusion(Project project, ActionType actionType, String deletedUser) {
 
     String actionDetail = String.format("%s 님이 %s 프로젝트에 제외되었습니다.", deletedUser, project.getName());
 
-    saveLog(project, null, actionType, deletedUser, actionDetail);
+    saveLog(project, null, actionType, deletedUser, actionDetail, null, null);
   }
 }

--- a/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
@@ -47,7 +47,7 @@ public class CollaboratorQueryService {
         project, user, roleType, TRUE);
   }
 
-  public Collaborator findByProjectAndCollaboratorIsConfirmed(Project project, User commentAuthor) {
-    return collaboratorRepository.findByProjectAndCollaboratorAndConfirmType(project, commentAuthor, TRUE);
+  public Collaborator findByProjectAndCollaboratorIsConfirmed(Project project, User user) {
+    return collaboratorRepository.findByProjectAndCollaboratorAndConfirmType(project, user, TRUE);
   }
 }

--- a/src/main/java/com/todo/exception/ErrorCode.java
+++ b/src/main/java/com/todo/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
   COLLABORATOR_NOT_FOUND(NOT_FOUND, "협업자를 찾을 수 없습니다."),
   COMMENT_NOT_FOUND(NOT_FOUND, "댓글을 찾을 수 없습니다."),
   NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림을 찾을 수 없습니다."),
+  SNAPSHOT_NOT_FOUND(NOT_FOUND, "저장된 스냅샷을 찾을 수 없습니다."),
 
   // 408 REQUEST TIMEOUT
 

--- a/src/main/java/com/todo/snapshot/controller/SnapshotController.java
+++ b/src/main/java/com/todo/snapshot/controller/SnapshotController.java
@@ -1,0 +1,28 @@
+package com.todo.snapshot.controller;
+
+import com.todo.snapshot.service.SnapShotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/todos")
+@RequiredArgsConstructor
+public class SnapshotController {
+
+  private final SnapShotService snapShotService;
+
+  @PostMapping("/{todoId}/restore/{snapshotId}")
+  public ResponseEntity<Void> restoreTodo(Authentication auth,
+      @PathVariable Long todoId,
+      @PathVariable Long snapshotId) {
+
+    snapShotService.restoreTodo(auth, todoId, snapshotId);
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/todo/snapshot/entity/Snapshot.java
+++ b/src/main/java/com/todo/snapshot/entity/Snapshot.java
@@ -1,0 +1,63 @@
+package com.todo.snapshot.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.todo.todo.entity.Todo;
+import com.todo.todo.type.TodoCategory;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "snapshots")
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class Snapshot {
+
+  @Id
+  @GeneratedValue
+  private Long id;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "todo_id", nullable = false)
+  private Todo todo;
+
+  private String title;
+
+  private String description;
+
+  private TodoCategory todoCategory;
+
+  private boolean isCompleted;
+
+  private boolean isPriority;
+
+  private Long version;
+
+  private LocalDateTime dueDate;
+
+  public static Snapshot of(Todo todo) {
+
+    return Snapshot.builder()
+        .todo(todo)
+        .title(todo.getTitle())
+        .description(todo.getDescription())
+        .todoCategory(todo.getTodoCategory())
+        .isCompleted(todo.isCompleted())
+        .isPriority(todo.isPriority())
+        .version(todo.getVersion())
+        .dueDate(todo.getDueDate())
+        .build();
+  }
+}

--- a/src/main/java/com/todo/snapshot/repository/SnapShotRepository.java
+++ b/src/main/java/com/todo/snapshot/repository/SnapShotRepository.java
@@ -1,0 +1,7 @@
+package com.todo.snapshot.repository;
+
+import com.todo.snapshot.entity.Snapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SnapShotRepository extends JpaRepository<Snapshot, Long> {
+}

--- a/src/main/java/com/todo/snapshot/service/SnapShotService.java
+++ b/src/main/java/com/todo/snapshot/service/SnapShotService.java
@@ -1,0 +1,80 @@
+package com.todo.snapshot.service;
+
+import static com.todo.activity.type.ActionType.TODO;
+import static com.todo.collaborator.type.RoleType.EDITOR;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.exception.ErrorCode.PROJECT_NOT_FOUND;
+import static com.todo.exception.ErrorCode.SNAPSHOT_NOT_FOUND;
+
+import com.todo.activity.service.ActivityLogService;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.snapshot.entity.Snapshot;
+import com.todo.snapshot.repository.SnapShotRepository;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.service.TodoQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SnapShotService {
+
+  private final SnapShotRepository snapShotRepository;
+
+  private final UserQueryService userQueryService;
+
+  private final TodoQueryService todoQueryService;
+
+  private final ProjectQueryService projectQueryService;
+
+  private final CollaboratorQueryService collaboratorQueryService;
+
+  private final ActivityLogService activityLogService;
+
+  public Long saveSnapshot(Todo todo) {
+
+    return snapShotRepository.save(Snapshot.of(todo)).getId();
+  }
+
+  public void restoreTodo(Authentication auth, Long todoId, Long snapshotId) {
+
+    User user = userQueryService.findByEmail(auth.getName());
+
+    Todo todo = todoQueryService.findById(todoId);
+
+    Snapshot snapshot = snapShotRepository.findById(snapshotId)
+        .orElseThrow(() -> new CustomException(SNAPSHOT_NOT_FOUND));
+
+    Long projectId = todo.getProjectId();
+
+    if (projectId == null) {
+      throw new CustomException(PROJECT_NOT_FOUND);
+    }
+
+    Project project = projectQueryService.findById(projectId);
+
+    boolean isCollaborator = collaboratorQueryService.existsByProjectAndCollaboratorAndRoleTypeAndIsConfirmed(
+        project, user, EDITOR);
+
+    if (!isCollaborator) {
+      throw new CustomException(FORBIDDEN);
+    }
+
+    Long previousVersion = todo.getVersion();
+
+    todo.restoreTodo(snapshot);
+
+    Long currentVersion = todo.getVersion();
+
+    activityLogService.recordTodoRollback(
+        project, todo, TODO, user.getName(), previousVersion, currentVersion, snapshotId);
+  }
+}

--- a/src/main/java/com/todo/todo/entity/Todo.java
+++ b/src/main/java/com/todo/todo/entity/Todo.java
@@ -5,6 +5,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.todo.snapshot.entity.Snapshot;
 import com.todo.todo.dto.TodoDto;
 import com.todo.todo.dto.TodoUpdateDto;
 import com.todo.todo.type.TodoCategory;
@@ -80,6 +81,16 @@ public class Todo {
         .version(1L)
         .dueDate(todoDto.dueDate())
         .build();
+  }
+
+  public void restoreTodo(Snapshot snapshot) {
+
+    title = snapshot.getTitle();
+    description = snapshot.getDescription();
+    todoCategory = snapshot.getTodoCategory();
+    isCompleted = snapshot.isCompleted();
+    isPriority = snapshot.isPriority();
+    dueDate = snapshot.getDueDate();
   }
 
   public void update(TodoUpdateDto todoUpdateDto) {

--- a/src/main/java/com/todo/todo/service/TodoService.java
+++ b/src/main/java/com/todo/todo/service/TodoService.java
@@ -14,6 +14,7 @@ import com.todo.exception.CustomException;
 import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
+import com.todo.snapshot.service.SnapShotService;
 import com.todo.todo.dto.TodoDto;
 import com.todo.todo.dto.TodoFilterRequestDto;
 import com.todo.todo.dto.TodoFilterResponseDto;
@@ -53,6 +54,8 @@ public class TodoService {
 
   private final CollaboratorQueryService collaboratorQueryService;
 
+  private final SnapShotService snapShotService;
+
   private final TodoMapper todoMapper;
 
   @PersistenceContext
@@ -78,7 +81,10 @@ public class TodoService {
 
       notificationService.notifyTodoAddedByOthers(users, todo, project);
 
-      activityLogService.recordTodoCreation(project, todo, TODO, user.getName());
+      Long snapshotId = snapShotService.saveSnapshot(todo);
+
+      activityLogService.recordTodoCreation(
+          project, todo, TODO, user.getName(), todo.getVersion(), snapshotId);
 
     } else {
 
@@ -177,10 +183,14 @@ public class TodoService {
 
       notificationService.notifyTodoStatusChangedByOthers(users, todo, project);
 
+      Long snapshotId = snapShotService.saveSnapshot(todo);
+
       if (!todo.isCompleted()) {
-        activityLogService.recordTodoUpdate(project, todo, TODO, user.getName());
+        activityLogService.recordTodoUpdate(
+            project, todo, TODO, user.getName(), todo.getVersion(), snapshotId);
       } else {
-        activityLogService.recordTodoComplete(project, todo, TODO, user.getName());
+        activityLogService.recordTodoComplete(
+            project, todo, TODO, user.getName(), todo.getVersion(), snapshotId);
       }
     }
 

--- a/src/test/java/com/todo/activity/service/ActivityLogServiceTest.java
+++ b/src/test/java/com/todo/activity/service/ActivityLogServiceTest.java
@@ -123,7 +123,7 @@ class ActivityLogServiceTest {
     // given
     String actionDetail = String.format("%s 할일이 생성되었습니다.", todo.getTitle());
     // when
-    activityLogService.recordTodoCreation(project, todo, TODO, actionDetail);
+    activityLogService.recordTodoCreation(project, todo, TODO, actionDetail, todo.getVersion(), null);
     // then
     verify(activityLogRepository).save(any(ActivityLog.class));
   }

--- a/src/test/java/com/todo/snapshot/service/SnapShotServiceTest.java
+++ b/src/test/java/com/todo/snapshot/service/SnapShotServiceTest.java
@@ -1,0 +1,167 @@
+package com.todo.snapshot.service;
+
+import static com.todo.activity.type.ActionType.TODO;
+import static com.todo.collaborator.type.RoleType.EDITOR;
+import static com.todo.exception.ErrorCode.FORBIDDEN;
+import static com.todo.exception.ErrorCode.PROJECT_NOT_FOUND;
+import static com.todo.exception.ErrorCode.SNAPSHOT_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.todo.activity.service.ActivityLogService;
+import com.todo.collaborator.service.CollaboratorQueryService;
+import com.todo.exception.CustomException;
+import com.todo.project.entity.Project;
+import com.todo.project.service.ProjectQueryService;
+import com.todo.snapshot.entity.Snapshot;
+import com.todo.snapshot.repository.SnapShotRepository;
+import com.todo.todo.entity.Todo;
+import com.todo.todo.service.TodoQueryService;
+import com.todo.user.entity.User;
+import com.todo.user.service.UserQueryService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class SnapShotServiceTest {
+
+  @Mock
+  private SnapShotRepository snapShotRepository;
+  @Mock
+  private UserQueryService userQueryService;
+  @Mock
+  private TodoQueryService todoQueryService;
+  @Mock
+  private ProjectQueryService projectQueryService;
+  @Mock
+  private CollaboratorQueryService collaboratorQueryService;
+  @Mock
+  private ActivityLogService activityLogService;
+
+  @InjectMocks
+  private SnapShotService snapShotService;
+
+  private Authentication auth;
+  private User testUser;
+  private Todo todo;
+  private Snapshot snapshot;
+  private Project project;
+
+  @BeforeEach
+  void setUp() {
+
+    auth = new UsernamePasswordAuthenticationToken("test@test.com", null);
+
+    testUser = User.builder()
+        .id(1L)
+        .email("test@test.com")
+        .name("사용자")
+        .build();
+
+    project = Project.builder()
+        .id(10L)
+        .build();
+
+    todo = Todo.builder()
+        .id(30L)
+        .title("투두")
+        .projectId(project.getId())
+        .version(5L)
+        .dueDate(LocalDateTime.now().plusDays(1))
+        .build();
+
+    snapshot = Snapshot.builder()
+        .id(50L)
+        .todo(todo)
+        .title("스냅샷 투두")
+        .version(3L)
+        .dueDate(todo.getDueDate())
+        .build();
+  }
+
+  @Test
+  @DisplayName("투두 롤백에 성공한다")
+  void restore_todo_success() {
+    // given
+    when(userQueryService.findByEmail(auth.getName())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(snapShotRepository.findById(snapshot.getId())).thenReturn(Optional.of(snapshot));
+    when(collaboratorQueryService.existsByProjectAndCollaboratorAndRoleTypeAndIsConfirmed(
+        project, testUser, EDITOR)).thenReturn(true);
+    // when
+    snapShotService.restoreTodo(auth, todo.getId(), snapshot.getId());
+    // then
+    verify(activityLogService).recordTodoRollback(
+        eq(project),
+        eq(todo),
+        eq(TODO),
+        eq(testUser.getName()),
+        eq(todo.getVersion()),
+        eq(todo.getVersion()),
+        eq(snapshot.getId())
+    );
+  }
+
+  @Test
+  @DisplayName("스냅샷이 존재하지 않으면 투두 롤백에 실패한다")
+  void restore_todo_failure_snapshot_not_found() {
+    // given
+    when(userQueryService.findByEmail(auth.getName())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(snapShotRepository.findById(snapshot.getId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> snapShotService.restoreTodo(auth, todo.getId(), snapshot.getId()));
+    // then
+    assertEquals(e.getErrorCode(), SNAPSHOT_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("프로젝트가 존재하지 않으면 투두 롤백에 실패한다")
+  void restore_todo_failure_project_not_found() {
+    // given
+    Todo anotherTodo = Todo.builder()
+        .id(100L)
+        .author(testUser)
+        .build();
+
+    when(userQueryService.findByEmail(auth.getName())).thenReturn(testUser);
+    when(todoQueryService.findById(anotherTodo.getId())).thenReturn(anotherTodo);
+    when(snapShotRepository.findById(snapshot.getId())).thenReturn(Optional.of(snapshot));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> snapShotService.restoreTodo(auth, anotherTodo.getId(), snapshot.getId()));
+    // then
+    assertEquals(e.getErrorCode(), PROJECT_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("협업자 권한이 부족하면 투두 롤백에 실패한다")
+  void restore_todo_failure_forbidden() {
+    // given
+    when(userQueryService.findByEmail(auth.getName())).thenReturn(testUser);
+    when(todoQueryService.findById(todo.getId())).thenReturn(todo);
+    when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(snapShotRepository.findById(snapshot.getId())).thenReturn(Optional.of(snapshot));
+    when(collaboratorQueryService.existsByProjectAndCollaboratorAndRoleTypeAndIsConfirmed(
+        project, testUser, EDITOR)).thenReturn(false);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> snapShotService.restoreTodo(auth, todo.getId(), snapshot.getId()));
+    // then
+    assertEquals(e.getErrorCode(), FORBIDDEN);
+  }
+}

--- a/src/test/java/com/todo/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/todo/todo/service/TodoServiceTest.java
@@ -16,6 +16,7 @@ import com.todo.exception.CustomException;
 import com.todo.notification.service.NotificationService;
 import com.todo.project.entity.Project;
 import com.todo.project.service.ProjectQueryService;
+import com.todo.snapshot.service.SnapShotService;
 import com.todo.todo.dto.TodoDto;
 import com.todo.todo.dto.TodoFilterRequestDto;
 import com.todo.todo.dto.TodoFilterResponseDto;
@@ -64,6 +65,9 @@ class TodoServiceTest {
 
   @Mock
   private NotificationService notificationService;
+
+  @Mock
+  private SnapShotService snapShotService;
 
   @Mock
   private CollaboratorQueryService collaboratorQueryService;
@@ -118,6 +122,8 @@ class TodoServiceTest {
     TodoDto todoDto = new TodoDto(project.getId(), "할일", "설명", WORK, true, LocalDateTime.now());
     when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
     when(projectQueryService.findById(project.getId())).thenReturn(project);
+    when(todoRepository.save(any(Todo.class))).thenAnswer(
+        invocationOnMock -> invocationOnMock.getArgument(0));
     // when
     todoService.createTodo(auth, todoDto);
     // then
@@ -132,7 +138,8 @@ class TodoServiceTest {
     when(todoMapper.filterTodos(any(TodoFilterRequestDto.class))).thenReturn(todoList);
     when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
     // when
-    PageInfo<TodoFilterResponseDto> pageInfo = todoService.getTodos(auth, null, INDIVIDUAL, false, false,
+    PageInfo<TodoFilterResponseDto> pageInfo = todoService.getTodos(auth, null, INDIVIDUAL, false,
+        false,
         1, 10);
     // then
     assertEquals(todo.getId(), pageInfo.getList().get(0).id());


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- snapshot 관련 로직 구현: 할일 버전 업데이트 시 스냅샷 저장 로직, 할일의 특정 버전으로 롤백 기능 구현
## 📌 작업 이유 (Why)
- 할일 버전 관리를 위한 스냅샷 관련 로직 구현
## ✨ 변경 사항 (Changes)
- 활동 로그에 할일 버전과 스냅샷 아이디 추가
- 할일 생성 및 변경사항에 대해 스냅샷에 저장 로직 추가
- 할일의 특정 시점으로 롤백하는 로직 추가
## ✅ 테스트 (Tests)
- [ ] 스냅샷이 존재하지 않으면 투두 롤백에 실패한다
- [ ] 프로젝트가 존재하지 않으면 투두 롤백에 실패한다
- [ ] 협업자 권한이 부족하면 투두 롤백에 실패한다