### PR TITLE
hotfix: project GET 요청 관련 서버 로직 수정

### DIFF
--- a/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
+++ b/src/main/java/com/todo/collaborator/service/CollaboratorQueryService.java
@@ -36,10 +36,6 @@ public class CollaboratorQueryService {
     return collaboratorRepository.findByProject(project);
   }
 
-  public List<Project> findProjectsByCollaborator(User user) {
-    return collaboratorRepository.findProjectsByCollaborator(user, TRUE);
-  }
-
   public boolean existsByProjectAndCollaboratorAndRoleTypeAndIsConfirmed(Project project, User user,
       RoleType roleType) {
 

--- a/src/main/java/com/todo/project/repository/ProjectRepository.java
+++ b/src/main/java/com/todo/project/repository/ProjectRepository.java
@@ -4,12 +4,14 @@ import com.todo.project.entity.Project;
 import com.todo.user.entity.User;
 import java.util.List;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-  Page<Project> findByOwner(User owner, Pageable pageable);
-
   List<Project> findByNameContainingIgnoreCase(String keyword);
+
+  @Query("SELECT DISTINCT p FROM Project p LEFT JOIN Collaborator c ON c.project = p WHERE p.owner = :user OR (c.collaborator = :user AND c.confirmType = 'TRUE')")
+  Page<Project> findProjectByUser(User user, PageRequest of);
 }

--- a/src/test/java/com/todo/project/service/ProjectServiceTest.java
+++ b/src/test/java/com/todo/project/service/ProjectServiceTest.java
@@ -87,7 +87,7 @@ class ProjectServiceTest {
   void get_projects_success() {
     // given
     when(userQueryService.findByEmail(testUser.getEmail())).thenReturn(testUser);
-    when(projectRepository.findByOwner(testUser, PageRequest.of(0, 10))).thenReturn(
+    when(projectRepository.findProjectByUser(testUser, PageRequest.of(0, 10))).thenReturn(
         new PageImpl<>(List.of(testProject)));
     // when
     Page<ProjectPageResponseDto> projects = projectService.getProjects(auth, 1, 10);


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- project GET 요청 관련 서버 로직 수정
## 📌 작업 이유 (Why)
- 프로젝트가 10개 이상이 있을 때, 반환이 10개만 되는 이슈
- 내가 만든 프로젝트 + 내가 속한 프로젝트 를 각각 다른 DB 에서 확인 후 Set 으로 중복 제거 후, 메서드 내에서 페이징 처리 -> 불필요한 메모리 사용 및 성능 저하
## ✨ 변경 사항 (Changes)
- 프로젝트 JPQL 을 수정하여 한번에 모든 데이터를 가져 온 후, DB 에서 중복제거 및 페이징 처리
- 불필요한 페이징 메서드, Collaborators 쿼리 메서드 등 삭제