### PR TITLE
feat: search 관련 페이지 구현

### DIFF
--- a/frontend/src/components/ResponsiveLayout.tsx
+++ b/frontend/src/components/ResponsiveLayout.tsx
@@ -1,16 +1,19 @@
 import {Button, Drawer, Layout, Menu} from "antd";
-import {Link, Outlet} from "react-router-dom";
-import {MenuOutlined} from "@ant-design/icons";
+import {Link, Outlet, useNavigate} from "react-router-dom";
+import {MenuOutlined, SearchOutlined} from "@ant-design/icons";
 import "../style/ResponsiveLayout.css";
 import React, {useState} from "react";
 import LogoutButton from "./LogoutButton";
 import {useAuth} from "../context/AuthContext";
+import SearchModal from "./SearchModal";
 
 const {Header, Content, Footer} = Layout;
 
 const ResponsiveLayOut: React.FC = () => {
   const [drawerVisible, setDrawerVisible] = useState(false);
+  const [searchVisible, setSearchVisible] = useState(false);
   const {isLoggedIn} = useAuth();
+  const navigate = useNavigate();
 
   const showDrawer = () => {
     setDrawerVisible(true);
@@ -19,8 +22,6 @@ const ResponsiveLayOut: React.FC = () => {
   const closeDrawer = () => {
     setDrawerVisible(false);
   };
-
-  console.log("ResponseRayOut isLoggedIn : ", isLoggedIn);
 
   return (
       <Layout style={{minHeight: '100vh'}}>
@@ -34,13 +35,25 @@ const ResponsiveLayOut: React.FC = () => {
               justifyContent: "space-between",
               padding: "0 16px"
             }}>
-          <div className="logo">☑️ To - Do: 할일 정리 & 협업 도구</div>
-          <Button
-              type="text"
-              icon={<MenuOutlined style={{color: "#fff", fontSize: "20px"}}/>}
-              onClick={showDrawer}
-          />
+          <div
+              className="logo"
+              onClick={() => navigate('/dashboard')}
+              style={{cursor: "pointer"}}>☑️ To - Do: 할일 정리 & 협업 도구
+          </div>
+          <div style={{display: "flex", alignItems: "center", gap: "10px"}}>
+            <Button
+                type="text"
+                icon={<SearchOutlined style={{color: "#fff", fontSize: "20px"}}/>}
+                onClick={() => setSearchVisible(true)}
+            />
+            <Button
+                type="text"
+                icon={<MenuOutlined style={{color: "#fff", fontSize: "20px"}}/>}
+                onClick={showDrawer}
+            />
+          </div>
         </Header>
+        <SearchModal visible={searchVisible} onClose={() => setSearchVisible(false)}/>
         <Drawer
             placement="right"
             closable
@@ -77,7 +90,8 @@ const ResponsiveLayOut: React.FC = () => {
         </Content>
         <Footer style={{textAlign: 'center'}}>Todo App ©2025</Footer>
       </Layout>
-  );
+  )
+      ;
 };
 
 export default ResponsiveLayOut;

--- a/frontend/src/components/SearchModal.tsx
+++ b/frontend/src/components/SearchModal.tsx
@@ -1,0 +1,52 @@
+import React, {useEffect, useRef, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {Button, Input, InputRef, Modal} from "antd";
+import {SearchOutlined} from "@ant-design/icons";
+
+const SearchModal: React.FC<{ visible: boolean; onClose: () => void }> = ({visible, onClose}) => {
+  const [keyword, setKeyword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSearch = () => {
+    if (keyword.trim()) {
+      navigate(`/search?q=${encodeURIComponent(keyword)}`);
+      onClose();
+    }
+  };
+
+  const inputRef = useRef<InputRef>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [visible]);
+
+  return (
+      <Modal
+          title="검색"
+          open={visible}
+          onCancel={onClose}
+          footer={null}
+          centered
+      >
+        <Input
+            ref={inputRef}
+            placeholder="찾고자 하는 📝 할일 및 📁 프로젝트명을 입력해 주세요"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            onPressEnter={handleSearch}
+        />
+        <Button
+            type="primary"
+            icon={<SearchOutlined/>}
+            onClick={handleSearch}
+            style={{marginTop: 10, width: "100%"}}
+        >
+          검색
+        </Button>
+      </Modal>
+  );
+};
+
+export default SearchModal;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -161,7 +161,7 @@ const DashboardPage: React.FC = () => {
 
       return (
           <div style={{padding: '2rem'}}>
-            <Typography.Title level={1}>내 할일</Typography.Title>
+            <Typography.Title level={1}>📝 내 할일</Typography.Title>
             <Space style={{marginBottom: "1rem"}}>
               <Button
                   type={showAllCompleted ? "primary" : "default"}
@@ -205,7 +205,7 @@ const DashboardPage: React.FC = () => {
                 loadMore={loadMoreData}
                 hasMore={hasMore}
             />
-            <Typography.Title level={1}>내 프로젝트</Typography.Title>
+            <Typography.Title level={1}>📁 내 프로젝트</Typography.Title>
             <Button
                 type="primary"
                 onClick={() => setProjectModalVisible(true)}

--- a/frontend/src/pages/SearchResultPage.tsx
+++ b/frontend/src/pages/SearchResultPage.tsx
@@ -1,0 +1,138 @@
+import React, {useCallback, useEffect, useRef, useState} from "react";
+import {useNavigate, useSearchParams} from "react-router-dom";
+import api from "../services/api";
+import {List, Spin, Typography} from "antd";
+import TodoDetailModal from "../components/TodoDetailModal";
+
+interface SearchResult {
+  id: number;
+  name: string;
+  type: "TODO" | "PROJECT"
+  isCompleted: boolean;
+}
+
+const SearchResultPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const keyword = searchParams.get("q") || "";
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const observer = useRef<IntersectionObserver | null>(null);
+  const [selectedTodoId, setSelectedTodoId] = useState<string | null>(null);
+  const [detailModalVisible, setDetailModalVisible] = useState(false);
+  const navigate = useNavigate();
+
+  const fetchSearchResults = async (reset = false) => {
+    if (!keyword) return;
+
+    setLoading(true);
+    try {
+      const response = await api.get<{
+        list: SearchResult[]
+        hasNextPage: boolean;
+      }>("/search", {
+        params: {q: keyword, page, pageSize: 10}
+      });
+
+      const newResults = response.data.list;
+
+      setResults((prevResults) =>
+          reset ? newResults : [...prevResults, ...newResults]
+      );
+      setHasMore(response.data.hasNextPage);
+    } catch (error) {
+      console.error("검색 실패", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSearchResults(true);
+  }, [keyword]);
+
+  useEffect(() => {
+    if (page > 1) fetchSearchResults();
+  }, [page]);
+
+  const lastElementRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        if (loading || !hasMore) return;
+        if (observer.current) observer.current.disconnect();
+
+        observer.current = new IntersectionObserver((entries) => {
+          if (entries[0].isIntersecting) {
+            setPage((prevPage) => prevPage + 1);
+          }
+        });
+
+        if (node) observer.current.observe(node);
+      }, [loading, hasMore]
+  );
+
+  return (
+      <div style={{padding: "2rem"}}>
+        <Typography.Title level={2}>
+          "{keyword}" 검색결과
+        </Typography.Title>
+        {loading && page === 1 ? (
+            <Spin style={{display: "block", textAlign: "center", marginBottom: "2rem"}}/>
+        ) : results.length > 0 ? (
+            <List
+                bordered
+                dataSource={results}
+                renderItem={(item, index) => (
+                    <List.Item
+                        ref={index === results.length - 1 ? lastElementRef : null}
+                        onClick={() => {
+                          if (item.type === "TODO") {
+                            setSelectedTodoId(item.id.toString());
+                            setDetailModalVisible(true);
+                          } else {
+                            navigate(`/projects/${item.id}/todos`)
+                          }
+                        }}
+                        style={{cursor: "pointer"}}
+                    >
+                      <Typography.Title level={5} style={{
+                        fontWeight: "bold",
+                        color: "#000",
+                        margin: 0,
+                        display: "flex",
+                        alignItems: "center"
+                      }}>
+                        <span style={{
+                          marginRight: "8px",
+                          fontSize: "18px",
+                          fontWeight: "bold",
+                          color: item.type === "TODO" ? "#2e7d32" : "#1565c0",
+                          background: item.type === "TODO" ? "#c8e6c9" : "#bbdefb",
+                          padding: "4px 8px",
+                          borderRadius: "20px",
+                          display: "inline-block"
+                        }}>
+                        {item.type === "TODO" ? "📝 Todo" : "📁 Project"}
+                        </span>
+                        {item.name}
+                      </Typography.Title>
+                    </List.Item>
+                )}
+            />
+        ) : (
+            <Typography.Title level={4} style={{fontWeight: "bold", color: "#000"}}>검색 결과가
+              없습니다.</Typography.Title>
+        )}
+        {loading && <Spin style={{display: "block", textAlign: "center", marginTop: "1rem"}}/>}
+
+        <TodoDetailModal
+            todoId={selectedTodoId}
+            visible={detailModalVisible}
+            onClose={() => setDetailModalVisible(false)}
+            onTodoUpdated={() => fetchSearchResults(true)}
+        />
+      </div>
+  );
+};
+
+export default SearchResultPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -5,6 +5,7 @@ import ResponsiveLayout from "../components/ResponsiveLayout";
 import LoginPage from "../pages/LoginPage";
 import DashboardPage from "../pages/DashboardPage";
 import ProjectTodosPage from "../pages/ProjectTodosPage";
+import SearchResultPage from "../pages/SearchResultPage";
 
 const AppRoutes = () => {
   return (
@@ -15,6 +16,7 @@ const AppRoutes = () => {
             <Route path="sign-up" element={<SignUpPage/>}/>
             <Route path="dashboard" element={<DashboardPage/>}/>
             <Route path="projects/:projectId/todos" element={<ProjectTodosPage/>}/>
+            <Route path="search" element={<SearchResultPage/>}/>
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/main/java/com/todo/project/repository/ProjectRepository.java
+++ b/src/main/java/com/todo/project/repository/ProjectRepository.java
@@ -2,15 +2,12 @@ package com.todo.project.repository;
 
 import com.todo.project.entity.Project;
 import com.todo.user.entity.User;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-
-  List<Project> findByNameContainingIgnoreCase(String keyword);
 
   @Query("SELECT DISTINCT p FROM Project p LEFT JOIN Collaborator c ON c.project = p WHERE p.owner = :user OR (c.collaborator = :user AND c.confirmType = 'TRUE')")
   Page<Project> findProjectByUser(User user, PageRequest of);

--- a/src/main/java/com/todo/search/controller/SearchController.java
+++ b/src/main/java/com/todo/search/controller/SearchController.java
@@ -1,13 +1,14 @@
 package com.todo.search.controller;
 
+import com.github.pagehelper.PageInfo;
 import com.todo.search.dto.SearchResponseDto;
 import com.todo.search.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,12 +24,13 @@ public class SearchController {
 
   @GetMapping
   @Operation(summary = "이름 기반 검색 API", description = "투두 및 프로젝트 제목(이름) 을 기준으로 %{검색어}% 로 검색이 가능합니다.")
-  public ResponseEntity<Page<SearchResponseDto>> search(
+  public ResponseEntity<PageInfo<SearchResponseDto>> search(
+      Authentication auth,
       @RequestParam(value = "q") String keyword,
       @RequestParam(value = "page", defaultValue = "1") @Min(1) int page,
       @RequestParam(value = "pageSize", defaultValue = "10") @Min(1) int pageSize) {
 
-    Page<SearchResponseDto> response = searchService.search(keyword, page, pageSize);
+    PageInfo<SearchResponseDto> response = searchService.search(auth, keyword, page, pageSize);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/todo/search/service/SearchService.java
+++ b/src/main/java/com/todo/search/service/SearchService.java
@@ -1,20 +1,13 @@
 package com.todo.search.service;
 
-import static com.todo.search.type.SearchType.PROJECT;
-import static com.todo.search.type.SearchType.TODO;
-
-import com.todo.project.entity.Project;
-import com.todo.project.repository.ProjectRepository;
+import com.github.pagehelper.PageHelper;
+import com.github.pagehelper.PageInfo;
 import com.todo.search.dto.SearchResponseDto;
-import com.todo.todo.entity.Todo;
 import com.todo.todo.mapper.TodoMapper;
-import java.util.ArrayList;
-import java.util.Collections;
+import com.todo.user.service.UserQueryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,56 +18,16 @@ public class SearchService {
 
   private final TodoMapper todoMapper;
 
-  private final ProjectRepository projectRepository;
+  private final UserQueryService userQueryService;
 
-  public Page<SearchResponseDto> search(String keyword, int page, int pageSize) {
+  public PageInfo<SearchResponseDto> search(Authentication auth, String keyword,
+      int page, int pageSize) {
 
-    List<SearchResponseDto> todoResults = searchTodos(keyword);
+    Long userId = userQueryService.findByEmail(auth.getName()).getId();
 
-    List<SearchResponseDto> projectResults = searchProjects(keyword);
+    PageHelper.startPage(page, pageSize);
+    List<SearchResponseDto> results = todoMapper.searchTodosAndProjects(keyword, userId);
 
-    List<SearchResponseDto> combinedResults = new ArrayList<>();
-    combinedResults.addAll(todoResults);
-    combinedResults.addAll(projectResults);
-
-    return paginateResults(combinedResults, page, pageSize);
-  }
-
-  private List<SearchResponseDto> searchTodos(String keyword) {
-
-    List<Todo> todos = todoMapper.searchTodosByTitle(keyword);
-    return todos.stream().map(
-            todo -> new SearchResponseDto(
-                todo.getId(),
-                todo.getTitle(),
-                TODO,
-                todo.isCompleted()))
-        .toList();
-  }
-
-  private List<SearchResponseDto> searchProjects(String keyword) {
-
-    List<Project> projects = projectRepository.findByNameContainingIgnoreCase(keyword);
-    return projects.stream().map(
-            project -> new SearchResponseDto(
-                project.getId(),
-                project.getName(),
-                PROJECT,
-                null))
-        .toList();
-  }
-
-  private Page<SearchResponseDto> paginateResults(List<SearchResponseDto> combinedResults, int page,
-      int pageSize) {
-
-    int total = combinedResults.size();
-    int fromIndex = (page - 1) * pageSize;
-    int toIndex = Math.min(fromIndex + pageSize, total);
-
-    List<SearchResponseDto> pageContent = fromIndex < total ?
-        combinedResults.subList(fromIndex, toIndex)
-        : Collections.emptyList();
-
-    return new PageImpl<>(pageContent, PageRequest.of(page - 1, pageSize), total);
+    return new PageInfo<>(results);
   }
 }

--- a/src/main/java/com/todo/todo/mapper/TodoMapper.java
+++ b/src/main/java/com/todo/todo/mapper/TodoMapper.java
@@ -1,5 +1,6 @@
 package com.todo.todo.mapper;
 
+import com.todo.search.dto.SearchResponseDto;
 import com.todo.todo.dto.TodoFilterRequestDto;
 import com.todo.todo.entity.Todo;
 import java.util.List;
@@ -11,5 +12,5 @@ public interface TodoMapper {
 
   List<Todo> filterTodos(TodoFilterRequestDto todoFilterRequestDto);
 
-  List<Todo> searchTodosByTitle(@Param("keyword") String keyword);
+  List<SearchResponseDto> searchTodosAndProjects(@Param("keyword") String keyword, @Param("userId") Long userId);
 }

--- a/src/main/resources/mapper/TodoMapper.xml
+++ b/src/main/resources/mapper/TodoMapper.xml
@@ -51,20 +51,15 @@
     </where>
   </select>
 
-  <select id="searchTodosByTitle" parameterType="String" resultMap="TodoResultMap">
-    SELECT t.id,
-           t.project_id,
-           t.title,
-           t.description,
-           t.todo_category,
-           t.is_completed,
-           t.is_priority,
-           t.version,
-           t.due_date,
-           t.created_at,
-           u.id as author_id
+  <select id="searchTodosAndProjects" resultType="com.todo.search.dto.SearchResponseDto">
+    SELECT t.id, t.title AS name, 'TODO' AS TYPE, t.is_completed
     FROM todos t
-           LEFT JOIN users u ON t.author_id = u.id
     WHERE t.title LIKE CONCAT('%', #{keyword}, '%')
+    UNION
+    SELECT p.id, p.name AS name, 'PROJECT' AS TYPE, NULL AS is_completed
+    FROM projects p
+    LEFT JOIN collaborators c ON c.project_id = p.id
+    WHERE p.name LIKE CONCAT('%', #{keyword}, '%')
+    AND (p.owner_id = #{userId} OR (c.collaborator_id = #{userId} AND c.confirm_type = 'TRUE'))
   </select>
 </mapper>


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- search 관련 페이지 구현
## ✨ 변경 사항 (Changes)
- todos 의 title, projects 의 name 필드의 일부를 확인하여 검색이 가능
- 검색후 새로운 페이지로 이동하며 검색결과는 Todo 와 Project 의 구분이 쉽게 확인할 수 있도록 구현
- 검색된 Todo 는 선택하면 Detail 모달이 열리며 수정이 가능한 상태로 구현
- 검색된 Proejct 는 선택하면 Project Page 로 넘어가게끔 구현
- 서버 사이드 페이징 최적화를 위해 Mybatis 쿼리 수정 및 Service 로직 변경